### PR TITLE
fix(rtk-rewrite): trust stdout over rtk exit code

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,21 +13,33 @@
  * user's choice to exclude shell output from model context is preserved.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { spawnSync } from "node:child_process";
+
 import {
   createBashTool,
   createLocalBashOperations,
+  type ExtensionAPI,
 } from "@mariozechner/pi-coding-agent";
-import { execFileSync } from "node:child_process";
 
 const REWRITE_TIMEOUT_MS = 5000;
 
 function rtkRewriteCommand(command: string): string | undefined {
+  // rtk's exit codes encode permission verdicts (0 = allow, 1 = no equivalent,
+  // 2 = deny, 3 = ask). Pi has its own approval flow for bash tool calls, so we
+  // trust stdout as the rewrite and let Pi gate execution. We only skip the
+  // rewrite when rtk explicitly produced no replacement (exit 1, empty stdout)
+  // or when rtk itself failed to run.
   try {
-    return execFileSync("rtk", ["rewrite", command], {
+    const result = spawnSync("rtk", ["rewrite", command], {
       encoding: "utf-8",
       timeout: REWRITE_TIMEOUT_MS,
-    }).trimEnd();
+    });
+
+    if (result.error) return undefined; // spawn failed (rtk not on PATH, timeout, etc.)
+
+    const out = (result.stdout ?? "").trimEnd();
+
+    return out.length > 0 ? out : undefined; // empty stdout = exit 1 "no rtk equivalent"
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary

`pi-rtk` 0.3.0 silently no-ops in production: `rtkRewriteCommand` calls `execFileSync`, which throws on any non-zero exit, but `rtk rewrite` in rtk 0.36+ exits **3** (its "ask" permission verdict) on the dominant success path — every destructive command, every `head`/`tail`, every pipe ending in head/tail. The catch returns `undefined`, `bashTool.spawnHook` falls back to the original command, and the extension produces zero token savings except on the narrow read-only exit-0 allow-list that landed upstream in [rtk-ai/rtk#1332](https://github.com/rtk-ai/rtk/pull/1332) (`ls`/`grep`/`find`/`wc`/`cat`).

This PR retargets `rtkRewriteCommand` to trust rewritten stdout regardless of exit code, matching the fix [rtk-ai/rtk#1075](https://github.com/rtk-ai/rtk/pull/1075) shipped for the Cursor hook and the same fix [rtk-ai/rtk#1388](https://github.com/rtk-ai/rtk/issues/1388) is asking OpenClaw to do.

Closes [#2](https://github.com/sherif-fanous/pi-rtk/issues/2). Thanks to [@axehomeyg](https://github.com/axehomeyg) for the thorough bug report, the upstream-issue cross-references that made the triage trivial, and the suggested patch shape this PR is built on.

## Why

rtk's exit codes encode a four-valued permission verdict by design (0=allow, 1=no equivalent, 2=deny, 3=ask) so host agents like Cursor and Claude Code can gate execution behind their own permission UIs. This contract is intentional ([rtk-ai/rtk#1155](https://github.com/rtk-ai/rtk/issues/1155), [rtk-ai/rtk#1232](https://github.com/rtk-ai/rtk/issues/1232)) and will not change upstream — flipping exit 3 → exit 0 globally would break every other consumer that relies on the verdict signal.

Pi already runs its own per-tool approval flow for bash commands, so stacking rtk's exit-3 "ask" verdict on top of Pi's prompt is redundant. The right semantic is: take rtk's rewritten command from stdout, hand it to Pi, and let Pi decide whether to prompt the user. That's exactly what this PR implements.

The narrower upstream improvement that *does* still have headroom is [rtk-ai/rtk#1232](https://github.com/rtk-ai/rtk/issues/1232) (adding `head`/`tail` and pipe-terminal read-only chains to the exit-0 allow-list). That would reduce how often exit 3 fires, but doesn't fix the underlying `execFileSync` trap and never gets us to "exit 0 for everything", so this downstream fix is needed regardless.

## What changes

- **`index.ts`** — replace `execFileSync` with `spawnSync` and treat non-empty stdout as authoritative regardless of exit code. Check `result.error` for spawn failures (rtk missing on `PATH`, timeout) that `execFileSync`'s throw previously caught for free. Empty stdout (the exit-1 "no rtk equivalent" case) still falls through to the original command. Reorder imports so the new `node:child_process` line sits in the builtin block, and fold the `ExtensionAPI` type import into the existing value import from `@mariozechner/pi-coding-agent` per the project's import order.
- **`index.ts`** (doc) — multi-line comment above `rtkRewriteCommand` documenting the exit-code semantics and the deliberate decision to ignore them, so the next maintainer doesn't "fix" this back to `execFileSync`.

## What does **not** change

- **The `spawnHook` and `user_bash` integration points.** Same call sites, same fall-back-on-`undefined` semantics — only the inside of `rtkRewriteCommand` changes.
- **Timeout behavior.** `REWRITE_TIMEOUT_MS` is still 5000 ms, just delivered via `spawnSync`'s `timeout` option instead of `execFileSync`'s.
- **`!!<cmd>` bypass.** Commands the user marks as excluded from context are still not intercepted.
- **Public extension API, package surface, dependencies.** Unchanged. No new runtime deps.

## Verification

- `rtk rewrite "git status"` exits 3 with stdout `rtk git status` — new code returns the rewrite, old code returned `undefined`.
- `rtk rewrite "<no-equivalent-command>"` exits 1 with empty stdout — both old and new code return `undefined` and fall through.
- `rtk` missing from `PATH` — `result.error` is set, function returns `undefined`, `bashTool` falls back to the original command.
- `mise run check` — lint, type-check, and format-check clean.
- End-to-end smoke on rtk 0.37.2 + pi 0.70.0: `rtk gain` starts recording savings as soon as the extension loads (vs. zero savings on `main`).
