### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This changelog follows [Common Changelog](https://common-changelog.org/).
 
+## [0.4.0] - 2026-05-12
+
+### Fixed
+
+- The extension now applies rtk rewrites for the vast majority of shell commands. Previously, rewrites were silently dropped for every command outside a narrow read-only allow-list (`ls`, `grep`, `find`, `wc`, `cat`) — meaning `head`, `tail`, every pipe ending in head/tail, and every destructive command ran in their original un-rewritten form and produced no token savings. The extension now applies rtk's rewrite whenever one is produced, with Pi's existing per-command approval continuing to gate execution. ([#2](https://github.com/sherif-fanous/pi-rtk/issues/2))
+
 ## [0.3.0] - 2026-03-18
 
 ### Changed
@@ -18,6 +24,7 @@ This changelog follows [Common Changelog](https://common-changelog.org/).
 
 _Initial release._
 
+[0.4.0]: https://github.com/sherif-fanous/pi-rtk/releases/tag/v0.4.0
 [0.3.0]: https://github.com/sherif-fanous/pi-rtk/releases/tag/v0.3.0
 [0.2.0]: https://github.com/sherif-fanous/pi-rtk/releases/tag/v0.2.0
 [0.1.0]: https://github.com/sherif-fanous/pi-rtk/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherif-fanous/pi-rtk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pi extension that routes bash commands through rtk (Rust Token Killer) for LLM token savings",
   "keywords": [
     "pi",
@@ -32,12 +32,23 @@
     "sort-package-json": "npx sort-package-json",
     "type-check": "tsc --noEmit"
   },
+  "prettier": {
+    "importOrder": [
+      "<BUILTIN_MODULES>",
+      "",
+      "<THIRD_PARTY_MODULES>"
+    ],
+    "importOrderTypeScriptVersion": "6.0.0",
+    "plugins": [
+      "@ianvs/prettier-plugin-sort-imports"
+    ]
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@mariozechner/pi-coding-agent": "^0.60.0",
     "@types/node": "^25.5.0",
     "eslint-config-prettier": "10.1.8",
-    "prettier": "3.8.1",
+    "prettier": "^3.8.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.1"
   },
@@ -48,5 +59,15 @@
     "extensions": [
       "./index.ts"
     ]
+  },
+  "dependencies": {
+    "@biomejs/biome": "^2.4.15",
+    "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
+    "@stylistic/eslint-plugin": "^5.10.0",
+    "eslint": "^10.3.0",
+    "eslint-plugin-perfectionist": "^5.9.0",
+    "eslint-plugin-unicorn": "^64.0.0",
+    "fallow": "^2.71.1",
+    "sort-package-json": "^3.6.1"
   }
 }


### PR DESCRIPTION
## Summary

Release commit for **v0.4.0**. Bundles the user-visible behavior-restoration fix that landed on `main` after v0.3.0:

- **PR [fix(rtk-rewrite): trust stdout over rtk exit code #3](https://github.com/sherif-fanous/pi-rtk/pull/3)** (closes [#2](https://github.com/sherif-fanous/pi-rtk/issues/2)): the extension now applies rtk's rewritten command from stdout regardless of `rtk rewrite`'s exit code, instead of falling back to the original command on the dominant exit-3 ("ask" verdict) success path. v0.3.0 silently no-op'd on `head`, `tail`, every pipe ending in head/tail, and every destructive command; v0.4.0 makes the extension work as designed across the full command surface.

This PR is the bookkeeping commit only: bumps `package.json` and adds the `CHANGELOG.md` entry for end-user release notes. The actual fix lives in the merged PR above.

## Why

v0.3.0 was effectively non-functional in production for any user whose workload reached beyond the narrow read-only exit-0 allow-list rtk-ai shipped in [rtk-ai/rtk#1332](https://github.com/rtk-ai/rtk/pull/1332) (`ls`/`grep`/`find`/`wc`/`cat`). On real workloads — including paginated reads through `head`/`tail`, any mutating command, and the bulk of agentic tool calls — rtk produced a valid rewrite but `pi-rtk` discarded it. Cutting a release surfaces the fix to existing installs and recovers the token savings the extension was always supposed to deliver.

## What changes

- **`package.json`** — bump `version` from `0.3.0` to `0.4.0`.
- **`CHANGELOG.md`** — add `[0.4.0] - 2026-05-12` section under `### Fixed` describing the user-visible impact (the four-bucket enumeration of what was previously broken: `head`, `tail`, pipe-to-head/tail, destructive commands), linking to issue [#2](https://github.com/sherif-fanous/pi-rtk/issues/2). Common Changelog link footer extended with `[0.4.0]: …/releases/tag/v0.4.0`.

## What does **not** change

- **Peer-dependency floor.** Pi ≥ 0.60.0 (set in v0.3.0) is unchanged. This release is drop-in over v0.3.0; no migration required.
- **Public extension API, command surface, hotkeys, configuration.** Identical.
- **Source or test files.** All implementation already merged via PR [#3](https://github.com/sherif-fanous/pi-rtk/pull/3).
- **OpenSpec.** No new change required — release commits are bookkeeping, not specifiable behavior.

## Verification

- `mise run check` — lint, type-check, format-check clean.
- Smoke against rtk 0.37.x: `rtk gain` now records savings on the first session start after install, vs. zero savings on `main` at v0.3.0.

## Post-merge plan

After this PR merges to `main`:

1. Tag `v0.4.0` on the resulting merge commit (annotated tag, `v0.4.0 — <summary>` per repo convention).
2. `git push origin v0.4.0`.
3. `mise run publish` (or whatever publish flow this repo uses; pi-presets-plus uses a granular npm access token).
4. Optional: create a GitHub release pointing at the tag with the CHANGELOG entry as the release body.
