### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This changelog follows [Common Changelog](https://common-changelog.org/).
 
+## [0.5.0] - 2026-05-12
+
+### Changed
+
+- **Breaking:** The extension now targets Pi published under the `@earendil-works` npm scope (Pi `0.74.0` and later). Pi has moved away from its old `@mariozechner` scope, and `pi-rtk` v0.5.0 will not load on Pi versions prior to `0.74.0`. Upgrade Pi to `0.74.0` or newer before upgrading this extension.
+
 ## [0.4.0] - 2026-05-12
 
 ### Fixed
@@ -24,6 +30,7 @@ This changelog follows [Common Changelog](https://common-changelog.org/).
 
 _Initial release._
 
+[0.5.0]: https://github.com/sherif-fanous/pi-rtk/releases/tag/v0.5.0
 [0.4.0]: https://github.com/sherif-fanous/pi-rtk/releases/tag/v0.4.0
 [0.3.0]: https://github.com/sherif-fanous/pi-rtk/releases/tag/v0.3.0
 [0.2.0]: https://github.com/sherif-fanous/pi-rtk/releases/tag/v0.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherif-fanous/pi-rtk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Pi extension that routes bash commands through rtk (Rust Token Killer) for LLM token savings",
   "keywords": [
     "pi",


### PR DESCRIPTION
## Summary

Release commit for **v0.5.0**. Bundles the breaking dependency-scope migration that landed on `main` after v0.4.0:

- **PR [chore: migrate pi-coding-agent dependency to @earendil-works npm scope](https://github.com/sherif-fanous/pi-rtk/pull/6)** (#6): retargets the `index.ts` import and `package.json` dev/peer dependency from `@mariozechner/pi-coding-agent` to `@earendil-works/pi-coding-agent` and bumps the pinned version to `^0.74.0`. Pi `0.74.0` is the first release published under the new scope; the old scope is no longer updated.

This is a **breaking** release for end users: `pi-rtk` v0.5.0 will not load against Pi versions older than `0.74.0`. Users must upgrade Pi first.

This PR is the bookkeeping commit only: bumps `package.json` and adds the `CHANGELOG.md` entry for end-user release notes. The actual migration lives in the merged PR above.

## What changes

- **`package.json`** — bump `version` from `0.4.0` to `0.5.0`.
- **`CHANGELOG.md`** — add `[0.5.0] - 2026-05-12` section under `### Changed`, flagged `**Breaking:**`, noting the `@earendil-works` scope move and the Pi ≥ `0.74.0` requirement. Release link `[0.5.0]: …/releases/tag/v0.5.0` prepended to the link footer in descending-version order.

Common Changelog format preserved (minor bump for a breaking change while still in `0.x`, per pre-1.0 SemVer convention that minor bumps signal user-visible compatibility shifts).

## What does **not** change

- **Source code, tests, or any non-bookkeeping file.** All implementation already merged via PR #6.
- **OpenSpec.** No new change required — release commits are bookkeeping, not specifiable behavior.

## Verification

- `mise run check` — `lint`, `type-check`, `format-check` clean.
- `pnpm install` — lockfile resolves cleanly against `@earendil-works/pi-coding-agent@0.74.0`.

## Post-merge plan

After this PR merges to `main`:

1. Tag `v0.5.0` on the resulting merge commit (annotated tag, `v0.5.0 — <summary>` per repo convention).
2. `git push origin v0.5.0`.
3. `mise run publish`.
4. Optional: create a GitHub release pointing at the tag with the CHANGELOG entry as the release body.
