### PR TITLE
docs: add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,154 @@
+# Agents
+
+## mise
+
+This project uses [mise](https://mise.jdx.dev/) as the task runner. mise
+automatically provisions the correct Node.js version (declared in `mise.toml`
+under `[tools]`) before every command, so the runtime is always consistent.
+
+Run any task with:
+
+```shell
+mise run <task>
+```
+
+### Available tasks
+
+| Task                         | Description                                                                                                                        |
+| :--------------------------- | :--------------------------------------------------------------------------------------------------------------------------------- |
+| `mise run check`             | Run format-check, type-check, and lint (the full pre-commit gate)                                                                  |
+| `mise run fallow`            | Run both `fallow-dead-code` and `fallow-dupes` as an advisory audit                                                                |
+| `mise run fallow-dead-code`  | Report unused exports / dead code via `fallow dead-code`                                                                           |
+| `mise run fallow-dupes`      | Report duplicated code via `fallow dupes`                                                                                          |
+| `mise run format`            | Auto-format source files with Prettier                                                                                             |
+| `mise run format-check`      | Check formatting without writing changes                                                                                           |
+| `mise run install-deps`      | Install npm dependencies                                                                                                           |
+| `mise run install-dev-deps`  | Install npm dev dependencies (`pnpm add --save-dev`)                                                                               |
+| `mise run lint`              | Lint source files with Biome and ESLint                                                                                            |
+| `mise run lint-fix`          | Auto-fix lint violations with Biome and ESLint                                                                                     |
+| `mise run login`             | Log in to npm via `pnpm login` (interactive; only needed if you don't use a token in `.env`)                                       |
+| `mise run pack-check`        | Run the full `check` gate, then `pnpm pack --dry-run` to verify the package builds and packs cleanly                               |
+| `mise run publish`           | Run `pack-check`, then publish to npm with `pnpm publish --access public` (auth via `NPM_ACCESS_TOKEN` from `.env` and `./.npmrc`) |
+| `mise run sort-package-json` | Sort `package.json` keys                                                                                                           |
+| `mise run type-check`        | Run TypeScript type checking                                                                                                       |
+| `mise run uninstall-deps`    | Uninstall npm dependencies                                                                                                         |
+| `mise run update-deps`       | Update npm dependencies                                                                                                            |
+
+## Code conventions
+
+The `fallow-*` tasks (and their `fallow` aggregator) are **advisory
+audits, not gates**. Run them periodically — e.g. before a release or
+when cleaning up a module — and use human judgement on the output.
+They are intentionally excluded from `check` because their reports
+routinely contain legitimate false positives (public API exports,
+intentionally-parallel code) that would make the pre-commit gate
+noisy and encourage reflexive "fix it to shut the tool up" refactors.
+
+Prettier, Biome, ESLint, and `tsc` enforce formatting, import order,
+naming, file-section ordering, kebab-case filenames, function-declaration
+style, and bans on `any` / `!` / `console.*` / one-letter identifiers.
+Run `mise run check` to surface violations across all four tools — most
+are auto-fixable via `mise run format` or `mise run lint-fix`.
+
+The conventions below are the ones the linter cannot enforce. They are
+project-wide unless noted.
+
+### Rewrite contract
+
+pi-rtk is a thin shim: the entire extension is a single `index.ts`
+that wires `rtk rewrite` into Pi's bash execution paths. The
+conventions below codify decisions baked into that file that are
+non-obvious from the code alone.
+
+- **Trust rtk's stdout, not its exit code.** `rtk rewrite` returns a
+  four-valued permission verdict via exit code (0 = allow, 1 = no
+  equivalent, 2 = deny, 3 = ask). Pi has its own per-tool approval
+  flow for bash commands, so `rtkRewriteCommand` ignores the exit
+  code and treats non-empty stdout as the authoritative rewrite. Do
+  NOT "fix" this back to `execFileSync` or to a `result.status === 0`
+  check — the exit-3 case is the dominant success path on modern rtk,
+  and the previous-execFileSync version silently dropped every
+  rewrite. See the in-source comment block above `rtkRewriteCommand`
+  for the full rationale and the issue-#2 / PR-#3 history.
+- **Return `undefined` to signal "no rewrite available".** Both
+  call sites (`spawnHook` and `user_bash`) chain through `?? command`
+  so that an undefined return causes a clean fall-through to the
+  original command. The two cases that produce `undefined` are:
+  rtk's empty-stdout "no equivalent" reply (exit 1) and any spawn
+  failure (rtk missing from PATH, timeout). Both are caller-invisible
+  by design.
+- **`REWRITE_TIMEOUT_MS = 5000` is the rtk-rewrite bound, not the
+  user-command bound.** If `rtk rewrite` itself hangs, fall through
+  to running the bare command after 5 seconds. The constant lives at
+  module scope (not inlined) so future tuning has one place to edit
+  and it shows up in `git log -L` cleanly.
+- **`!<cmd>` is intercepted, `!!<cmd>` is not.** Pi's `!!<cmd>` form
+  marks shell output as excluded from model context. Intercepting it
+  here would expose the model to output the user explicitly chose to
+  hide; the `event.excludeFromContext` guard in the `user_bash`
+  handler preserves that intent. Do NOT remove the guard "because
+  the rewrite is harmless" — the guard is about output visibility,
+  not rewrite safety.
+
+### Documentation
+
+- Every source file opens with a module-level JSDoc block stating:
+  (a) the file's role in one line, (b) what it owns vs. what it does
+  NOT own. Keep it high-level and change-agnostic — do NOT mention
+  OpenSpec change names, future-change extension points, or
+  implementation details (those belong on the relevant function/type,
+  in the OpenSpec proposal, or in inline comments).
+- Comments explain _why_, not _what_. Common patterns: rationale on
+  decisions that contradict an obvious "fix" (the exit-code-trust
+  block), inline notes naming exit-code-meaning relationships
+  (`// empty stdout = exit 1 "no rtk equivalent"`), and any
+  `try/catch` guard whose existence depends on rtk's contract.
+- Lifecycle handlers (`user_bash`, `bashTool.spawnHook`) wrap calls
+  in defense-in-depth handling for the rtk-unavailable / rtk-hangs
+  case. The fall-through-to-original-command behavior IS the guard;
+  do not add `try/catch` on top.
+
+## Commit messages
+
+Commit messages MUST follow [Conventional Commits](https://www.conventionalcommits.org/), i.e. `<type>(<optional-scope>): <subject>` on the first line, where `<type>` is one of:
+
+| Type       | Use for                                                                          |
+| :--------- | :------------------------------------------------------------------------------- |
+| `build`    | Build system, package manifest, or dependency changes                            |
+| `chore`    | Maintenance tasks that don't fit elsewhere (e.g. tooling config tweaks)          |
+| `ci`       | CI configuration changes                                                         |
+| `docs`     | Documentation-only changes (README, AGENTS.md, openspec proposals/designs, etc.) |
+| `feat`     | A new user-visible feature                                                       |
+| `fix`      | A bug fix                                                                        |
+| `perf`     | Performance improvements                                                         |
+| `refactor` | Code restructuring with no behavior change                                       |
+| `revert`   | Reverting a previous commit                                                      |
+| `style`    | Formatting / whitespace / lint-only fixes that don't change behavior             |
+| `test`     | Adding or updating tests                                                         |
+
+Guidelines:
+
+- Subject is in the imperative mood ("add picker", not "added picker" or "adds picker"), lowercase, no trailing period, ideally ≤ 72 characters.
+- Use a scope when it sharpens meaning, e.g. `fix(rtk-rewrite): ...` or `chore(deps): ...`. Skip the scope when the change is broad.
+- Append `!` after the type/scope (e.g. `feat(rtk-rewrite)!: ...`) for a breaking change, and explain it in the body or a `BREAKING CHANGE:` footer.
+- Optional body (after a blank line) explains _why_; reference the OpenSpec change name when relevant (e.g. `Part of openspec change: handle-exit-3`).
+
+Examples:
+
+```text
+chore: bump prettier to 3.8.3
+fix(rtk-rewrite): trust stdout over rtk exit code
+chore: migrate pi dependencies to @earendil-works npm scope
+chore(release): v0.5.0
+```
+
+### Body conventions for substantial commits
+
+Commits that touch more than ~3 files SHOULD include a structured body. Use this skeleton:
+
+1. **One-paragraph "why"** — what this commit makes possible / what part of the project plan it advances. Reference the OpenSpec change name when relevant.
+2. **`What's in:` bullet list** — one bullet per _role_ (not one per file). Order bullets by purpose-cluster: manifest → build/lint configs → source → docs/legal → repo meta → openspec. Within the repo-meta cluster, list files in dependency order (a file gets introduced before any file that references it; e.g. `mise.toml` before `AGENTS.md`).
+3. **`Verified:` bullet list** — one bullet per check that was actually run (lint, type-check, format-check, install round-trip, pack contents, etc.).
+4. **Footer line** — `Closes openspec change: <name>.` for the commit that finishes a change, or `Part of openspec change: <name>.` for incremental commits.
+
+Keep bullets ≤ 2 lines each; wrap the body at 72 columns.


### PR DESCRIPTION
## Summary

Codify pi-rtk's contributor conventions in an `AGENTS.md` at the repo root. The document is purely descriptive of the current state — every rule it contains matches the code as committed today.

## Why

Three things deserve a written-down record so they don't drift or get re-litigated each time someone touches `index.ts`:

1. **The mise task surface.** The repo now uses mise as the canonical entry point for `format` / `lint` / `type-check` / `pack-check` / `publish`. The task table documents what each task does so contributors don't have to read `mise.toml` to find them.
2. **The rewrite contract.** The exit-code-trust decision (don't fix back to `execFileSync`; trust stdout regardless of rtk's permission verdict), the `undefined`-on-no-op contract that the bash hook fall-through relies on, the 5-second timeout boundary, and the `!!<cmd>` non-intercept guard are all non-obvious from a 70-line file. The PR #3 / issue #2 history is the cautionary tale: the previous-`execFileSync` version silently dropped every rewrite, and a future "cleanup" PR could easily revert to that shape without this guidance. The AGENTS.md section names each decision and points readers at the in-source comment block for the full rationale.
3. **The commit-message format.** Conventional Commits with a body skeleton for substantial commits, so anyone (human or agent) writing a commit knows the expected structure.

## What changes

- **`AGENTS.md`** (new) — repo conventions document. Three sections: `## mise` (task surface), `## Code conventions` (with `### Rewrite contract` and `### Documentation` subsections), and `## Commit messages` (with body skeleton for substantial commits).

## What does **not** change

- **Source code, configuration, dependencies.** None touched.
- **The `mise.toml` task definitions.** AGENTS.md documents them; their definitions in `mise.toml` are the source of truth.
- **The `### Rewrite contract` decisions.** They're documented here, not changed. Every rule was already implicit in `index.ts` and its in-source comment block.

## Verification

- The document is descriptive, not aspirational. Every rule in `### Rewrite contract` and `### Documentation` matches `index.ts` as committed:
  - Module-level JSDoc: present (`index.ts:1-14`).
  - Exit-code-trust comment block: present (above `rtkRewriteCommand`).
  - Inline exit-meaning notes: present (`// spawn failed (rtk not on PATH, timeout, etc.)`, `// empty stdout = exit 1 "no rtk equivalent"`).
  - Fall-through-as-guard pattern: present in both `spawnHook` and the `user_bash` handler.
- `mise run check` — lint, type-check, format-check clean (AGENTS.md is markdown; not lint-gated).

## Post-merge plan

No release commit, no tag, no npm publish. The document lives at the repo root and is read by future contributors and agent tooling.
