### PR TITLE
docs: codify pi-rtk's no-deny-enforcement scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ non-obvious from the code alone.
 - Comments explain _why_, not _what_. Common patterns: rationale on
   decisions that contradict an obvious "fix" (the exit-code-trust
   block), inline notes naming exit-code-meaning relationships
-  (`// empty stdout = exit 1 "no rtk equivalent"`), and any
+  (`// empty stdout = exit 1 OR exit 2`), and any
   `try/catch` guard whose existence depends on rtk's contract.
 - Lifecycle handlers (`user_bash`, `bashTool.spawnHook`) wrap calls
   in defense-in-depth handling for the rtk-unavailable / rtk-hangs

--- a/README.md
+++ b/README.md
@@ -107,3 +107,13 @@ User !!<cmd>
         ▼
     bypass pi-rtk and use normal Pi context-excluded shell handling
 ```
+
+## What pi-rtk Does Not Do
+
+`pi-rtk` is a rewrite shim. It does not gate, prompt for, sandbox, or deny commands based on their content, including when `rtk rewrite` surfaces a deny verdict.
+
+That scope is intentional. `rtk`'s deny verdict comes from a permission source that does not match Pi's permission model, and Pi's built-in approval flow plus Pi's extension ecosystem cover command gating better as composable layers.
+
+If you want command-level permissions, guardrails, or shields, install a dedicated Pi extension for that. Browse [pi.dev/packages](https://pi.dev/packages) filtered by extension and search for terms like `permission`, `guardrail`, or `shield`.
+
+Those extensions compose with `pi-rtk`: they block disallowed commands at execution time, whether or not `pi-rtk` has rewritten the command.

--- a/index.ts
+++ b/index.ts
@@ -27,8 +27,16 @@ function rtkRewriteCommand(command: string): string | undefined {
   // rtk's exit codes encode permission verdicts (0 = allow, 1 = no equivalent,
   // 2 = deny, 3 = ask). Pi has its own approval flow for bash tool calls, so we
   // trust stdout as the rewrite and let Pi gate execution. We only skip the
-  // rewrite when rtk explicitly produced no replacement (exit 1, empty stdout)
-  // or when rtk itself failed to run.
+  // rewrite when rtk explicitly produced no replacement (exit 1, empty stdout),
+  // produced a deny verdict without a rewrite (exit 2, empty stdout), or when
+  // rtk itself failed to run.
+  //
+  // rtk's exit 2 deny verdict is derived from its own permission rules, loaded
+  // by src/hooks/permissions.rs::load_permission_rules. Those rules do not map
+  // cleanly onto Pi's permission model, so command-level gating in Pi remains
+  // the responsibility of Pi's approval flow or a dedicated Pi permission
+  // extension. See the README's "What pi-rtk Does Not Do" section for the
+  // user-facing rationale.
   try {
     const result = spawnSync("rtk", ["rewrite", command], {
       encoding: "utf-8",
@@ -39,7 +47,7 @@ function rtkRewriteCommand(command: string): string | undefined {
 
     const out = (result.stdout ?? "").trimEnd();
 
-    return out.length > 0 ? out : undefined; // empty stdout = exit 1 "no rtk equivalent"
+    return out.length > 0 ? out : undefined; // empty stdout = exit 1 OR exit 2
   } catch {
     return undefined;
   }

--- a/openspec/changes/archive/2026-05-13-document-rtk-deny-passthrough/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-13-document-rtk-deny-passthrough/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-13

--- a/openspec/changes/archive/2026-05-13-document-rtk-deny-passthrough/design.md
+++ b/openspec/changes/archive/2026-05-13-document-rtk-deny-passthrough/design.md
@@ -1,0 +1,114 @@
+## Context
+
+`pi-rtk` is a thin shim that wires `rtk rewrite` into Pi's bash execution
+paths (the agent `bash` tool via `createBashTool({ spawnHook })`, and
+context-visible user shell commands via the `user_bash` event). The
+existing `AGENTS.md § Rewrite contract` documents the "trust stdout,
+ignore exit code" decision behind `rtkRewriteCommand`. That decision was
+made for the rewrite verdicts (allow, no equivalent, ask). The deny
+verdict was not explicitly addressed because, at the time, the silent
+fall-through happened to produce the desired behavior.
+
+This change does not alter behavior. It captures the implicit decision
+about the deny verdict as an explicit spec requirement and surfaces the
+rationale where users (README) and contributors (source comment) will
+find it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `pi-rtk`'s non-enforcement of `rtk`'s deny verdict an explicit
+  contract in `openspec/specs/user-interaction/spec.md` so a future
+  contributor cannot "fix" it into an enforcement gate without
+  consciously amending the spec.
+- Give users a one-paragraph user-facing explanation of the scope
+  decision, with a generic pointer to the Pi package catalog for
+  command-level gating.
+- Give contributors the rtk-specific reason inline at the only call
+  site (`rtkRewriteCommand`) so the code itself answers the question
+  "why isn't this handling exit 2?".
+
+**Non-Goals:**
+
+- Implementing deny enforcement, even behind a flag. That is a separate
+  conversation and would require a different scope and a different
+  extension architecture (Pi `tool_call` listener rather than
+  `createBashTool` spawn hook).
+- Adding configuration surface to `pi-rtk` (env vars, sidecar config,
+  etc.). AGENTS.md takes an explicit zero-config stance; this change
+  does not relax it.
+- Cross-linking AGENTS.md and README to each other. The two files have
+  different release lifecycles and the deliberate separation should be
+  preserved.
+
+## Decisions
+
+### Decision: lock the behavior in `user-interaction`, not `shell-optimization`
+
+The deny case is framed as "what `pi-rtk` does not do to the user." The
+`user-interaction` capability is the natural home for that framing (it
+already owns Transparent Operation, Non-Disruptive Fallback, and
+Respect For User Context Visibility Choice). `shell-optimization`
+covers the optimization machinery itself and is silent on refusal
+semantics by design.
+
+Alternative considered: place the requirement in `shell-optimization`
+as a corollary of the rewrite contract. Rejected because the requirement
+is about a user-facing absence of behavior, not an optimization pathway.
+
+### Decision: explicitly forbid pi-rtk-originated refusal messages
+
+The new requirement includes "AND `pi-rtk` MUST NOT emit a refusal
+message of its own." Without this clause, a contributor could argue
+that printing a `[pi-rtk] command denied by rtk: ...` warning is
+consistent with passing the command through. That would still violate
+Transparent Operation by inference, but only weakly; the explicit
+clause makes the contract unambiguous.
+
+### Decision: README section placed at the end of the file
+
+The user requested end-of-file placement. The trade-off was visibility
+(between How It Works and Prerequisites) vs. install-flow continuity
+(end of file). End-of-file preserves the install/use narrative for new
+users and treats the scope explanation as reference material for users
+who go looking after a surprise.
+
+### Decision: README points only to the Pi package catalog
+
+The README does not name specific permission, guardrail, or shield
+extensions. Reasons: the catalog already has search and type filters;
+naming specific packages incurs ongoing maintenance to keep links
+fresh; and `pi-rtk` should not appear to endorse one gating extension
+over another.
+
+### Decision: source comment references rtk's internal location
+
+The deny-verdict paragraph in `rtkRewriteCommand` mentions
+`src/hooks/permissions.rs::load_permission_rules` in the upstream rtk
+repo. That string survives most refactors (function-name granularity)
+and gives a contributor enough to verify the claim without leaving
+their editor. If rtk relocates that function, the comment becomes
+mildly stale but remains grep-able. Acceptable trade-off vs. the
+maintenance cost of pinned line numbers.
+
+## Risks / Trade-offs
+
+- **Risk**: Users who switch from Claude Code expect Pi to honor the
+  same deny rules. → **Mitigation**: README section names the
+  divergence explicitly and points to permission extensions in the
+  catalog. AGENTS.md continues to document the "trust stdout" stance.
+
+- **Risk**: rtk evolves so that deny verdicts come from a Pi-native or
+  rtk-native source (not `.claude/settings.json`), invalidating the
+  stated rationale. → **Mitigation**: the spec requirement is framed
+  as "based on a permission verdict surfaced by `rtk rewrite`,"
+  independent of where that verdict originates, so it remains
+  meaningful even if rtk's deny source changes. Only the README
+  paragraph and source comment would need a refresh.
+
+- **Trade-off**: contributors who skim the source might still wonder
+  why the code does not branch on exit code. → **Accepted**: the
+  existing exit-code-trust block plus the new deny paragraph together
+  cover the reasoning; tightening further would lose the rationale
+  this change is trying to lock in.

--- a/openspec/changes/archive/2026-05-13-document-rtk-deny-passthrough/proposal.md
+++ b/openspec/changes/archive/2026-05-13-document-rtk-deny-passthrough/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+`rtk rewrite` returns more than a rewrite — it also surfaces a permission
+verdict (allow, no equivalent, deny, ask). `pi-rtk` currently inspects
+only stdout and so, by default, lets denied commands fall through to
+Pi's normal execution path. That behavior is correct for `pi-rtk`'s
+scope as a rewrite shim, but it is implicit: nothing in the specs or
+public docs commits to it, so a future contributor could plausibly
+"fix" `pi-rtk` into a permission gate that silently couples Pi
+behavior to a Claude Code config file. This change locks the current
+behavior into the spec and documents the rationale where users and
+contributors will see it.
+
+## What Changes
+
+- Add a new requirement to the `user-interaction` capability stating
+  that `pi-rtk` MUST NOT refuse execution based on `rtk rewrite`'s
+  permission verdict, MUST allow Pi's normal shell execution path to
+  proceed, and MUST NOT emit a refusal message of its own.
+- Add a README section (`What pi-rtk Does Not Do`) at the end of the
+  README that explains the scope decision in user-facing terms and
+  directs users to the Pi package catalog at
+  [pi.dev/packages](https://pi.dev/packages) for permission /
+  guardrail / shield extensions.
+- Extend the existing source-level rationale comment on
+  `rtkRewriteCommand` in `index.ts` with a paragraph explaining why
+  the deny verdict is not enforced, and correct the inline
+  `// empty stdout = exit 1` comment to reflect that empty stdout
+  also covers the deny case (exit 2).
+
+No behavior change. Documentation- and contract-only.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None. -->
+
+### Modified Capabilities
+
+- `user-interaction`: adds a new requirement codifying that `pi-rtk`
+  does not refuse execution based on `rtk`'s permission verdict.
+
+## Impact
+
+- `openspec/specs/user-interaction/spec.md`: new requirement appended.
+- `README.md`: new end-of-file section.
+- `index.ts`: comment-only edits on `rtkRewriteCommand` (rationale
+  paragraph plus one inline-comment fix).
+- No runtime behavior change. No API change. No dependency change.

--- a/openspec/changes/archive/2026-05-13-document-rtk-deny-passthrough/specs/user-interaction/spec.md
+++ b/openspec/changes/archive/2026-05-13-document-rtk-deny-passthrough/specs/user-interaction/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: No Refusal On rtk Permission Verdict
+
+The system MUST NOT refuse to execute a shell command based on a
+permission verdict surfaced by `rtk rewrite`. Command-level refusal is
+the responsibility of Pi's built-in approval flow or of a dedicated Pi
+permission extension installed by the user.
+
+#### Scenario: rtk surfaces a deny verdict
+
+- **WHEN** `rtk rewrite` indicates that a shell command submitted to
+  `pi-rtk` matches a deny rule
+- **THEN** `pi-rtk` MUST NOT block command execution
+- **AND** the command MUST continue through Pi's normal shell
+  execution path
+- **AND** `pi-rtk` MUST NOT emit a refusal message of its own
+
+#### Scenario: rtk surfaces a non-deny verdict
+
+- **WHEN** `rtk rewrite` returns an allow, no-equivalent, or ask
+  verdict for a shell command submitted to `pi-rtk`
+- **THEN** existing rewrite and fall-through behavior MUST apply
+  unchanged
+- **AND** the new requirement MUST NOT alter handling of those
+  verdicts

--- a/openspec/changes/archive/2026-05-13-document-rtk-deny-passthrough/tasks.md
+++ b/openspec/changes/archive/2026-05-13-document-rtk-deny-passthrough/tasks.md
@@ -1,0 +1,52 @@
+## 1. Spec
+
+- [x] 1.1 Append the `No Refusal On rtk Permission Verdict` requirement
+      (both scenarios) to `openspec/specs/user-interaction/spec.md`,
+      copied verbatim from
+      `openspec/changes/document-rtk-deny-passthrough/specs/user-interaction/spec.md`.
+
+## 2. README
+
+- [x] 2.1 Add a new section titled `What pi-rtk Does Not Do` at the end
+      of `README.md` (after the existing `User !!<cmd> shell commands`
+      block).
+- [x] 2.2 In that section, explain in user-facing terms that `pi-rtk`
+      is a rewrite shim and does not gate, prompt, sandbox, or deny
+      commands based on content — including `rtk`'s deny verdict.
+- [x] 2.3 Give two short rationales: (1) rtk's deny verdict comes from
+      a permission source that does not match Pi's permission model;
+      (2) Pi's built-in approval flow plus the Pi extension ecosystem
+      cover gating better as composable layers.
+- [x] 2.4 Point users to [pi.dev/packages](https://pi.dev/packages),
+      filtered by extension, with suggested search terms like
+      `permission`, `guardrail`, or `shield`. Do not name specific
+      packages.
+- [x] 2.5 State the composition order explicitly: when a permission
+      extension is installed alongside `pi-rtk`, the permission
+      extension runs first on the original command.
+
+## 3. Source comment
+
+- [x] 3.1 In `index.ts`, append a deny-verdict rationale paragraph to
+      the existing exit-code-trust comment block above
+      `rtkRewriteCommand`. The paragraph must (a) name exit 2 as the
+      deny verdict, (b) cite rtk's
+      `src/hooks/permissions.rs::load_permission_rules` as the source
+      of the deny rules, (c) state that command-level gating in Pi is
+      the responsibility of Pi's approval flow or a Pi permission
+      extension, and (d) cross-reference the new README section.
+- [x] 3.2 Update the inline `// empty stdout = exit 1 "no rtk
+equivalent"` comment to reflect that empty stdout also covers
+      exit 2 (e.g. `// empty stdout = exit 1 OR exit 2`).
+
+## 4. Verification
+
+- [x] 4.1 `mise run check` passes (format-check, type-check, lint).
+- [x] 4.2 `openspec validate document-rtk-deny-passthrough --strict`
+      passes.
+- [x] 4.3 Manual: read README end-to-end and confirm the new section
+      reads cleanly in isolation (no missing context from removed
+      cross-links).
+- [x] 4.4 Manual: grep `index.ts` for `excludeFromContext`,
+      `REWRITE_TIMEOUT_MS`, and the existing exit-code-trust block to
+      confirm none of the existing rationale was perturbed.

--- a/openspec/specs/user-interaction/spec.md
+++ b/openspec/specs/user-interaction/spec.md
@@ -63,3 +63,28 @@ The system MUST keep user bash optimization non-disruptive during normal operati
 - **WHEN** a supported shell command executed through Pi's `!<cmd>` syntax is optimized successfully
 - **THEN** the command MUST complete without requiring additional user interaction solely for optimization reporting
 - **AND** the user experience MUST remain consistent with normal shell execution
+
+### Requirement: No Refusal On rtk Permission Verdict
+
+The system MUST NOT refuse to execute a shell command based on a
+permission verdict surfaced by `rtk rewrite`. Command-level refusal is
+the responsibility of Pi's built-in approval flow or of a dedicated Pi
+permission extension installed by the user.
+
+#### Scenario: rtk surfaces a deny verdict
+
+- **WHEN** `rtk rewrite` indicates that a shell command submitted to
+  `pi-rtk` matches a deny rule
+- **THEN** `pi-rtk` MUST NOT block command execution
+- **AND** the command MUST continue through Pi's normal shell
+  execution path
+- **AND** `pi-rtk` MUST NOT emit a refusal message of its own
+
+#### Scenario: rtk surfaces a non-deny verdict
+
+- **WHEN** `rtk rewrite` returns an allow, no-equivalent, or ask
+  verdict for a shell command submitted to `pi-rtk`
+- **THEN** existing rewrite and fall-through behavior MUST apply
+  unchanged
+- **AND** the new requirement MUST NOT alter handling of those
+  verdicts


### PR DESCRIPTION
## Summary

`rtk rewrite` returns more than a rewrite — it also surfaces a permission verdict (allow, no equivalent, deny, ask). `pi-rtk` today already ignores the deny verdict at runtime because the existing exit-code-trust block in `rtkRewriteCommand` only inspects stdout, and rtk emits empty stdout on the deny path. That implicit behavior was correct, but nothing in the specs or public docs committed to it. This PR locks the existing behavior into the spec, gives users a user-facing explanation of the scope decision, and documents the rationale where contributors will find it. **No runtime behavior change.**

## Why

Two motivations:

1. **Prevent a plausible future regression.** A future contributor reading `index.ts` could read the exit-code-trust block, notice that exit 2 (rtk's deny verdict) is being implicitly passed through, and "fix" `pi-rtk` into a permission gate. Doing so would silently couple Pi's runtime behavior to a Claude Code config file (`.claude/settings.json`) that the Pi user may not own or maintain. Making the non-enforcement an explicit spec requirement means that change cannot land without consciously amending the spec — and the AGENTS.md / README / source comment together explain *why* the spec says what it does.

2. **Set user expectations correctly.** A Pi user coming from Claude Code may expect `pi-rtk` to honor the same `Bash(...)` deny rules they already configured. The new README section makes the scope boundary explicit and points to the Pi package catalog for permission, guardrail, and shield extensions that compose with `pi-rtk` as separate, user-installed layers.

The rtk deny verdict is derived from `.claude/settings.json` files loaded by `src/hooks/permissions.rs::load_permission_rules` in the upstream rtk repo. That permission source does not match Pi's permission model, so enforcing the verdict inside a Pi extension would create divergence with rtk for zero new functionality — command-level gating in Pi belongs to Pi's built-in approval flow or to a dedicated Pi permission / guardrail / shield extension installed by the user, not to a rewrite shim.

## What changes

* **`openspec/specs/user-interaction/spec.md`** — new requirement `No Refusal On rtk Permission Verdict` with two scenarios: (a) when rtk surfaces a deny verdict, `pi-rtk` MUST NOT block execution, MUST allow Pi's normal shell path to proceed, and MUST NOT emit a refusal message of its own; (b) when rtk surfaces a non-deny verdict (allow / no-equivalent / ask), existing rewrite and fall-through behavior MUST apply unchanged.
* **`README.md`** — new `What pi-rtk Does Not Do` section at the end of the file. Explains in user-facing terms that `pi-rtk` is a rewrite shim, gives a two-pronged rationale (rtk's deny source does not match Pi's permission model; layered tools compose better than monolithic ones), and points users to [pi.dev/packages](https://pi.dev/packages) filtered by extension with suggested search terms (`permission`, `guardrail`, `shield`). The section does not name specific packages and makes no ordering claims it cannot guarantee — it only asserts that gating extensions block disallowed commands at execution time, whether or not `pi-rtk` has rewritten the command.
* **`index.ts`** — appended a deny-verdict rationale paragraph to the existing exit-code-trust comment block above `rtkRewriteCommand`, naming exit 2 as the deny verdict, citing rtk's `src/hooks/permissions.rs::load_permission_rules` as the source of the deny rules, and cross-referencing the README section. Also updated the inline comment `// empty stdout = exit 1 "no rtk equivalent"` to `// empty stdout = exit 1 OR exit 2` to reflect that empty stdout also covers the deny case.
* **`AGENTS.md`** — updated the verbatim inline-comment example in the Documentation conventions section to match the new wording in `index.ts`. Keeps the cited example accurate without cross-linking AGENTS.md and README (whose release lifecycles stay deliberately separate).
* **`openspec/changes/archive/2026-05-13-document-rtk-deny-passthrough/`** — the completed change's proposal, design, spec delta, and task list, moved from the active changes directory after all artifacts and tasks were marked done.

## What does **not** change

* **Runtime behavior.** `rtkRewriteCommand` returns the same values for the same inputs as before. Spawn count, exit-code handling, fall-through semantics, and timeout behavior are byte-identical.
* **`package.json`, dependencies, lockfile.** Untouched.
* **`AGENTS.md` "Rewrite contract" section structure.** Only the verbatim inline-comment example was updated; the surrounding rationale is unchanged.
* **CHANGELOG.** No entry — this is documentation-and-contract-only and does not warrant a release on its own. The next user-visible release commit (a feature change) will mention it in passing.
* **Cross-links between AGENTS.md and README.** Deliberately kept separate per `AGENTS.md` § Rewrite contract conventions. The two files share decisions but have different release lifecycles.

## Verification

* `mise run check` — `format-check`, `type-check`, `biome lint`, and `eslint .` all clean.
* `openspec validate document-rtk-deny-passthrough --strict` — passed (re-run before the archive move).
* Manual: read `README.md` end-to-end; the new section reads cleanly in isolation with no broken cross-references.
* Manual: grepped `index.ts` for `excludeFromContext`, `REWRITE_TIMEOUT_MS`, and the existing exit-code-trust block — none of the existing rationale was perturbed.

## Closes openspec change

`document-rtk-deny-passthrough`.
