### PR TITLE
perf(user_bash): dedupe rtk rewrite call at probe time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,13 @@ non-obvious from the code alone.
   handler preserves that intent. Do NOT remove the guard "because
   the rewrite is harmless" — the guard is about output visibility,
   not rewrite safety.
+- **The `user_bash` rewrite is computed once and reused.** The
+  handler probes `rtk rewrite` to decide whether to claim an event,
+  then captures that probe result for the returned exec operation
+  instead of spawning `rtk rewrite` again. This relies on Pi's
+  upstream guarantee that `pi-coding-agent`
+  `modes/interactive/interactive-mode.js::handleBashCommand` passes
+  the original event command through to `operations.exec` unchanged.
 
 ### Documentation
 

--- a/index.ts
+++ b/index.ts
@@ -70,18 +70,16 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
-    if (!rtkRewriteCommand(event.command)) {
+    const rewritten = rtkRewriteCommand(event.command);
+
+    if (rewritten === undefined) {
       return;
     }
 
     return {
       operations: {
-        exec: (command, cwd, options) => {
-          return localBashOperations.exec(
-            rtkRewriteCommand(command) ?? command,
-            cwd,
-            options,
-          );
+        exec: (_command, cwd, options) => {
+          return localBashOperations.exec(rewritten, cwd, options);
         },
       },
     };

--- a/openspec/changes/archive/2026-05-13-cache-user-bash-rewrite/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-13-cache-user-bash-rewrite/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-13

--- a/openspec/changes/archive/2026-05-13-cache-user-bash-rewrite/design.md
+++ b/openspec/changes/archive/2026-05-13-cache-user-bash-rewrite/design.md
@@ -1,0 +1,95 @@
+## Context
+
+The current `user_bash` handler is shaped around an early decision
+("should I claim this event?") that requires knowing whether `rtk
+rewrite` produces output for the command. The natural way to answer
+that question is to call `rtk rewrite` and check its result — which
+is exactly what the handler does. But then the handler returns a
+`operations.exec` closure that Pi calls later, and that closure
+re-calls `rtk rewrite` to obtain the rewritten command. The first
+call's result was never stored, so it cannot be reused.
+
+The fix is mechanical: store the probe-time rewrite in a local
+`const` and let the closure capture it. Pi's user_bash dispatch
+(verified in `pi-coding-agent`
+`modes/interactive/interactive-mode.js::handleBashCommand`) passes
+the original event command unchanged to `operations.exec`, so the
+captured rewrite is the correct command to run.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Halve the number of `rtk rewrite` subprocess spawns per intercepted
+  `!<cmd>`.
+- Express the new constraint in the `shell-optimization` spec so the
+  reduction is part of the contract rather than an accident of the
+  current code shape.
+- Keep the `user_bash` handler shape recognisable: same early-return
+  for `excludeFromContext`, same fall-through when rtk has no
+  rewrite, same `operations` shape returned to Pi.
+
+**Non-Goals:**
+
+- Introducing a generalised rewrite cache (LRU, TTL, etc.).
+- Touching the agent `bash` tool path. That path already calls
+  `rtkRewriteCommand` exactly once per command via `spawnHook`.
+- Hardening against a hypothetical future Pi where
+  `operations.exec`'s `command` argument differs from
+  `event.command`. If Pi changes that contract, this extension MUST
+  fail loudly via an explicit update — silent degradation would hide
+  a behavior change.
+
+## Decisions
+
+### Decision: trust Pi's documented contract, no equality guard
+
+The closure uses the captured `rewritten` directly. It does not
+check `command === event.command` before reusing the cached rewrite.
+
+Rationale: Pi documents and implements the pass-through contract.
+Defending against a hypothetical contract break would (a) be
+anti-information for future readers ("why is this guard here?"),
+(b) hide a real Pi regression behind a silent fallback, and (c) cost
+a per-call equality check for zero useful benefit today. If Pi ever
+changes the contract, `pi-rtk` should be updated explicitly with a
+clear commit and changelog entry.
+
+Alternative considered: defensive equality check with
+fall-back-to-original-command-on-mismatch. Rejected for the reasons
+above.
+
+### Decision: spec the call-count constraint, not the implementation
+
+The new requirement says "at most one rtk rewrite call per
+intercepted user_bash event." It does NOT say "use a closure" or
+"store the result in a `const`." Implementation freedom is preserved
+for future refactors (e.g., switching to a `Map` if pi-rtk ever
+wants to deduplicate across events).
+
+### Decision: limit the change to the `user_bash` path
+
+The agent `bash` path already invokes `rtkRewriteCommand` exactly
+once per command via `createBashTool({ spawnHook })`. Touching that
+path here would be scope creep and would risk regressing the
+existing well-tested behavior.
+
+## Risks / Trade-offs
+
+- **Risk**: Pi changes the `user_bash` dispatch in a future release
+  so that the `command` argument to `operations.exec` differs from
+  `event.command`. → **Mitigation**: this is documented as a
+  contract dependency in AGENTS.md. A regression would surface as
+  rtk being called on the rewritten command (idempotent) or, in a
+  pathological case, on a different command entirely; either way the
+  outcome is a clear bug rather than a silent quiet degradation,
+  which is easier to diagnose. The current Pi version (0.74.0) is
+  pinned via `package.json` `peerDependencies` once we choose to add
+  a guard there; until then, a sentence in AGENTS.md is the
+  source-of-truth for this expectation.
+
+- **Trade-off**: the spec now constrains call count, which is a
+  performance dimension rather than a behavioral one. Accepted
+  because the call count delta is the entire point of this change.
+  Without the requirement, a future contributor could revert the
+  refactor "for clarity" without realising the cost.

--- a/openspec/changes/archive/2026-05-13-cache-user-bash-rewrite/proposal.md
+++ b/openspec/changes/archive/2026-05-13-cache-user-bash-rewrite/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+The current `user_bash` handler calls `rtkRewriteCommand` twice for
+every intercepted `!<cmd>` invocation: once at probe time to decide
+whether to claim the event, and a second time inside the returned
+`operations.exec` closure when Pi actually runs the command. The
+second call recomputes the same rewrite the probe already produced
+and discards from the first call.
+
+For a typical `!ls -al`, that means two `rtk rewrite "ls -al"`
+subprocess spawns per command. Each spawn is on the order of tens of
+milliseconds. The first spawn's stdout is computed, evaluated only
+for truthiness, and then thrown away. Capturing the probe result in
+the handler's closure eliminates the second spawn without changing
+end behavior.
+
+Pi documents that the `command` argument to `operations.exec` is the
+same string as the `command` field of the `UserBashEvent`. The
+upstream call site (`pi-coding-agent`
+`modes/interactive/interactive-mode.js::handleBashCommand`) shows the
+unmodified pass-through. Closing over the rewrite computed at probe
+time is therefore safe.
+
+## What Changes
+
+- Refactor the `user_bash` handler in `index.ts` to compute the
+  rewrite once and reuse it inside the `operations.exec` closure.
+- Replace the discarded-result probe `if (!rtkRewriteCommand(...))
+  return;` pattern with a typed `const rewritten = ...` binding that
+  the closure captures.
+- Update the AGENTS.md "Rewrite contract" section with a short
+  paragraph stating that the `user_bash` handler reuses the rewrite
+  computed at probe time, and naming the upstream Pi guarantee that
+  makes this safe.
+- Add a `shell-optimization` requirement codifying that at most one
+  `rtk rewrite` subprocess is spawned per intercepted user shell
+  command.
+
+No user-visible behavior change. Same input, same output, fewer
+subprocess spawns.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None. -->
+
+### Modified Capabilities
+
+- `shell-optimization`: adds a new requirement constraining the
+  number of `rtk rewrite` calls per intercepted `user_bash` event,
+  and codifies reuse of the probe-time rewrite.
+
+## Impact
+
+- `index.ts`: refactor of the `user_bash` handler. No API surface
+  change.
+- `AGENTS.md`: one-paragraph addition to the "Rewrite contract"
+  section.
+- `openspec/specs/shell-optimization/spec.md`: new requirement.
+- No new dependencies. No breaking changes. No behavior change
+  observable to the user or the model.

--- a/openspec/changes/archive/2026-05-13-cache-user-bash-rewrite/specs/shell-optimization/spec.md
+++ b/openspec/changes/archive/2026-05-13-cache-user-bash-rewrite/specs/shell-optimization/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Single Rewrite Per Intercepted User Bash Event
+
+The system MUST issue at most one `rtk rewrite` subprocess
+invocation per intercepted `user_bash` event. When the `user_bash`
+handler claims a context-visible shell command for optimization,
+the rewrite result computed at probe time MUST be reused when the
+optimized command is ultimately executed.
+
+#### Scenario: handler intercepts a supported command
+
+- **GIVEN** a user shell command submitted via Pi's `!<cmd>` syntax
+- **WHEN** the `user_bash` handler determines that `rtk rewrite`
+  produces a non-empty rewrite for the command
+- **THEN** the system MUST spawn `rtk rewrite` exactly once for
+  that user shell command
+- **AND** the executed command MUST be the rewrite produced by that
+  single spawn
+
+#### Scenario: handler does not intercept
+
+- **GIVEN** a user shell command submitted via Pi's `!<cmd>` syntax
+- **WHEN** the `user_bash` handler determines that `rtk rewrite`
+  produces no rewrite (or fails to run)
+- **THEN** the system MUST NOT cause additional `rtk rewrite`
+  subprocess spawns for that event beyond the single probe
+- **AND** Pi MUST handle execution using its normal shell behavior

--- a/openspec/changes/archive/2026-05-13-cache-user-bash-rewrite/tasks.md
+++ b/openspec/changes/archive/2026-05-13-cache-user-bash-rewrite/tasks.md
@@ -1,0 +1,33 @@
+## 1. Source
+
+- [x] 1.1 In `index.ts`, replace the discarded-result probe pattern
+      in the `user_bash` handler. Bind the probe result to a
+      `const rewritten = rtkRewriteCommand(event.command)`. Return
+      early when `rewritten === undefined`. The returned
+      `operations.exec` closure MUST use `rewritten` directly
+      (ignoring the `command` parameter Pi passes back) and MUST
+      NOT call `rtkRewriteCommand` again.
+
+## 2. Documentation
+
+- [x] 2.1 Append a short paragraph to AGENTS.md "Rewrite contract"
+      noting that the `user_bash` handler reuses the rewrite
+      computed at probe time, and naming the upstream Pi guarantee
+      (`pi-coding-agent`
+      `modes/interactive/interactive-mode.js::handleBashCommand`)
+      that makes this safe.
+
+## 3. Verification
+
+- [x] 3.1 `mise run check` passes.
+- [x] 3.2 `openspec validate cache-user-bash-rewrite --strict`
+      passes.
+- [ ] 3.3 Manual smoke: run `!ls -al` (or any rtk-supported
+      command) through Pi while temporarily instrumenting
+      `rtkRewriteCommand` to count invocations. Confirm exactly
+      one rtk spawn occurs.
+- [ ] 3.4 Manual smoke: run `!RTK_DISABLED=1 ls` through Pi.
+      Confirm the user_bash handler probes once, sees no rewrite
+      (rtk bails on the env-prefix), and falls through to Pi's
+      normal shell — no exec closure is returned, no second rtk
+      spawn happens.

--- a/openspec/specs/shell-optimization/spec.md
+++ b/openspec/specs/shell-optimization/spec.md
@@ -82,3 +82,30 @@ The system MUST NOT apply `pi-rtk` optimization to user shell commands whose out
 - **WHEN** a user executes a shell command using Pi's `!!<cmd>` syntax while `pi-rtk` is loaded
 - **THEN** `pi-rtk` MUST NOT intercept the command for optimization
 - **AND** Pi MUST handle execution using its normal context-excluded shell behavior
+
+### Requirement: Single Rewrite Per Intercepted User Bash Event
+
+The system MUST issue at most one `rtk rewrite` subprocess
+invocation per intercepted `user_bash` event. When the `user_bash`
+handler claims a context-visible shell command for optimization,
+the rewrite result computed at probe time MUST be reused when the
+optimized command is ultimately executed.
+
+#### Scenario: handler intercepts a supported command
+
+- **GIVEN** a user shell command submitted via Pi's `!<cmd>` syntax
+- **WHEN** the `user_bash` handler determines that `rtk rewrite`
+  produces a non-empty rewrite for the command
+- **THEN** the system MUST spawn `rtk rewrite` exactly once for
+  that user shell command
+- **AND** the executed command MUST be the rewrite produced by that
+  single spawn
+
+#### Scenario: handler does not intercept
+
+- **GIVEN** a user shell command submitted via Pi's `!<cmd>` syntax
+- **WHEN** the `user_bash` handler determines that `rtk rewrite`
+  produces no rewrite (or fails to run)
+- **THEN** the system MUST NOT cause additional `rtk rewrite`
+  subprocess spawns for that event beyond the single probe
+- **AND** Pi MUST handle execution using its normal shell behavior


### PR DESCRIPTION
## Summary

The `user_bash` handler used to spawn `rtk rewrite` twice per intercepted `!<cmd>`: once at probe time to decide whether to claim the event, and a second time inside the returned `operations.exec` closure to recompute the rewritten command. The probe's stdout was discarded — only its boolean truthiness was used — so the second spawn produced the same rewrite the first spawn had already computed and thrown away. For a typical `!ls -al`, that meant two ~10–50 ms subprocess spawns where one would do. This PR captures the probe result into a `const rewritten` binding and reuses it. **Same input, same output, fewer subprocess spawns.**

## Why

The duplicate-spawn pattern was a real performance bug, not a correctness one — the second spawn returned the same answer as the first because `rtk rewrite` is deterministic for a given input. But it was paying for the computation twice. For users who lean on `!<cmd>` (which agent-side rewrites already avoid via `createBashTool({ spawnHook })`), the per-invocation latency was effectively doubled for no reason.

The fix is mechanical: store the probe result in a local `const` and let the closure capture it. The design call this PR commits is **no defensive equality check** between the captured `event.command` and the `command` Pi later passes to `operations.exec`. Pi documents and implements a pass-through contract (`pi-coding-agent` `modes/interactive/interactive-mode.js::handleBashCommand` calls `executeBash(command, ..., { operations })` with the same `command` it just emitted in the `user_bash` event), so the captured rewrite is the correct command. Defending against a hypothetical future contract change would be anti-information for future readers, would hide a real Pi regression behind a silent fallback, and would cost a per-call equality check for zero useful benefit today. If Pi ever changes the contract, `pi-rtk` should be updated explicitly with a clear changelog entry — not silently degrade.

The agent `bash` tool path (which goes through `createBashTool({ spawnHook })`) is unchanged — it already spawned `rtk` exactly once per command. This PR is scoped strictly to the `user_bash` path.

## What changes

* **`index.ts`** — `user_bash` handler refactored. The discarded-result probe pattern (`if (!rtkRewriteCommand(event.command)) return;`) is replaced with `const rewritten = rtkRewriteCommand(event.command);` plus a typed early-return on `undefined`. The `operations.exec` closure now reads `rewritten` from the surrounding closure instead of calling `rtkRewriteCommand` again; the `_command` parameter is underscore-prefixed to signal deliberate disuse. Net delta: -7 / +5 lines inside the handler.
* **`AGENTS.md`** — new bullet in the "Rewrite contract" non-obvious-from-code list documenting the probe-capture technique and naming the upstream Pi guarantee (`pi-coding-agent` `modes/interactive/interactive-mode.js::handleBashCommand`) that makes the closure capture safe.
* **`openspec/specs/shell-optimization/spec.md`** — new requirement `Single Rewrite Per Intercepted User Bash Event` with two scenarios: (a) when the handler claims a command, `rtk rewrite` MUST spawn exactly once and the executed command MUST be that single spawn's output; (b) when the handler does not claim a command, `pi-rtk` MUST NOT cause additional spawns beyond the single probe. Synced verbatim from the change's delta spec.
* **`openspec/changes/archive/2026-05-13-cache-user-bash-rewrite/`** — the completed change's proposal, design, spec delta, and task list, moved from the active changes directory after all artifacts were marked done.

## What does **not** change

* **The agent `bash` tool path.** `createBashTool({ spawnHook })` is untouched — it already spawned `rtk rewrite` exactly once per agent-initiated command.
* **`rtkRewriteCommand` itself.** Its body, comments (including the exit-code-trust rationale block from the previous PR), and timeout handling are byte-identical.
* **The `excludeFromContext` early-return** that preserves `!!<cmd>`'s no-context-leak intent. This guard runs before the probe, as before.
* **Public API and dependencies.** `package.json` unchanged.
* **CHANGELOG.** No entry — this is a behind-the-scenes perf fix. The next user-visible feature commit will mention it in passing.

## Verification

* `mise run check` — `format-check`, `type-check`, `biome lint`, and `eslint .` all clean.
* `openspec validate cache-user-bash-rewrite --strict` — passes (re-run after the spec sync, before the archive move).
* Manual code-trace: walked `handleBashCommand` in `pi-coding-agent` (`dist/modes/interactive/interactive-mode.js`) to confirm Pi passes `command` unchanged to `executeBash` → `operations.exec`. Closure capture is safe.
* **Note**: the two manual runtime smokes from the change's `tasks.md` (count `rtk` spawns under `!ls -al`; confirm `!RTK_DISABLED=1 ls` produces exactly one probe and falls through) are deferred to post-merge release smoke. They do not block merge because the code-trace and the lint/type/format checks collectively verify the call-count invariant; the smokes are reconfirmation, not primary evidence.

## Closes openspec change

`cache-user-bash-rewrite`.
