### PR TITLE
chore: trim rationale to load-bearing comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,50 +53,6 @@ are auto-fixable via `mise run format` or `mise run lint-fix`.
 The conventions below are the ones the linter cannot enforce. They are
 project-wide unless noted.
 
-### Rewrite contract
-
-pi-rtk is a thin shim: the entire extension is a single `index.ts`
-that wires `rtk rewrite` into Pi's bash execution paths. The
-conventions below codify decisions baked into that file that are
-non-obvious from the code alone.
-
-- **Trust rtk's stdout, not its exit code.** `rtk rewrite` returns a
-  four-valued permission verdict via exit code (0 = allow, 1 = no
-  equivalent, 2 = deny, 3 = ask). Pi has its own per-tool approval
-  flow for bash commands, so `rtkRewriteCommand` ignores the exit
-  code and treats non-empty stdout as the authoritative rewrite. Do
-  NOT "fix" this back to `execFileSync` or to a `result.status === 0`
-  check — the exit-3 case is the dominant success path on modern rtk,
-  and the previous-execFileSync version silently dropped every
-  rewrite. See the in-source comment block above `rtkRewriteCommand`
-  for the full rationale and the issue-#2 / PR-#3 history.
-- **Return `undefined` to signal "no rewrite available".** Both
-  call sites (`spawnHook` and `user_bash`) chain through `?? command`
-  so that an undefined return causes a clean fall-through to the
-  original command. The two cases that produce `undefined` are:
-  rtk's empty-stdout "no equivalent" reply (exit 1) and any spawn
-  failure (rtk missing from PATH, timeout). Both are caller-invisible
-  by design.
-- **`REWRITE_TIMEOUT_MS = 5000` is the rtk-rewrite bound, not the
-  user-command bound.** If `rtk rewrite` itself hangs, fall through
-  to running the bare command after 5 seconds. The constant lives at
-  module scope (not inlined) so future tuning has one place to edit
-  and it shows up in `git log -L` cleanly.
-- **`!<cmd>` is intercepted, `!!<cmd>` is not.** Pi's `!!<cmd>` form
-  marks shell output as excluded from model context. Intercepting it
-  here would expose the model to output the user explicitly chose to
-  hide; the `event.excludeFromContext` guard in the `user_bash`
-  handler preserves that intent. Do NOT remove the guard "because
-  the rewrite is harmless" — the guard is about output visibility,
-  not rewrite safety.
-- **The `user_bash` rewrite is computed once and reused.** The
-  handler probes `rtk rewrite` to decide whether to claim an event,
-  then captures that probe result for the returned exec operation
-  instead of spawning `rtk rewrite` again. This relies on Pi's
-  upstream guarantee that `pi-coding-agent`
-  `modes/interactive/interactive-mode.js::handleBashCommand` passes
-  the original event command through to `operations.exec` unchanged.
-
 ### Documentation
 
 - Every source file opens with a module-level JSDoc block stating:

--- a/index.ts
+++ b/index.ts
@@ -24,30 +24,20 @@ import {
 const REWRITE_TIMEOUT_MS = 5000;
 
 function rtkRewriteCommand(command: string): string | undefined {
-  // rtk's exit codes encode permission verdicts (0 = allow, 1 = no equivalent,
-  // 2 = deny, 3 = ask). Pi has its own approval flow for bash tool calls, so we
-  // trust stdout as the rewrite and let Pi gate execution. We only skip the
-  // rewrite when rtk explicitly produced no replacement (exit 1, empty stdout),
-  // produced a deny verdict without a rewrite (exit 2, empty stdout), or when
-  // rtk itself failed to run.
-  //
-  // rtk's exit 2 deny verdict is derived from its own permission rules, loaded
-  // by src/hooks/permissions.rs::load_permission_rules. Those rules do not map
-  // cleanly onto Pi's permission model, so command-level gating in Pi remains
-  // the responsibility of Pi's approval flow or a dedicated Pi permission
-  // extension. See the README's "What pi-rtk Does Not Do" section for the
-  // user-facing rationale.
+  // rtk's exit codes are permission verdicts (0/1/2/3 = allow/no-equiv/deny/
+  // ask). We trust stdout and ignore the exit code. The deny verdict is
+  // intentionally not enforced — this shim rewrites, it does not gate.
   try {
     const result = spawnSync("rtk", ["rewrite", command], {
       encoding: "utf-8",
       timeout: REWRITE_TIMEOUT_MS,
     });
 
-    if (result.error) return undefined; // spawn failed (rtk not on PATH, timeout, etc.)
+    if (result.error) return undefined;
 
     const out = (result.stdout ?? "").trimEnd();
 
-    return out.length > 0 ? out : undefined; // empty stdout = exit 1 OR exit 2
+    return out.length > 0 ? out : undefined; // empty stdout = exit 1 or 2
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary

The `AGENTS.md` "Rewrite contract" section had grown to five bullets, four of which restated what `index.ts` already showed. The exit-code-trust block was duplicated in both the source comment above `rtkRewriteCommand` and an near-identical bullet in `AGENTS.md`. `REWRITE_TIMEOUT_MS`'s purpose was obvious from its type signature and call site. The `undefined`-means-no-rewrite contract was visible in the return type plus the `?? command` chain at both call sites. Only two pieces of content were genuinely non-obvious — and one of them (the `user_bash` closure capture's reliance on a Pi upstream guarantee) had no inline comment next to the code that depended on it. This PR migrates the load-bearing rationale into source comments next to the code it justifies, and deletes the rest. **No behavior change.**

## Why

The project's `AGENTS.md` itself says (under "Documentation"): "Comments explain why, not what." The "Rewrite contract" section was quietly violating its own neighbor's principle by hosting rationale in a separate document, prone to staleness — which already bit us last week, when one of the section's verbatim inline-comment examples drifted out of sync with the actual `index.ts` text and needed a follow-up fix. The section was also growing monotonically: it gained a fifth bullet on the previous PR (perf dedupe), and would have gained two more on the in-flight changes (`notify-when-rtk-unavailable`, `add-rtk-slash-command`). Each new bullet would create another staleness hook.

The fix is to draw a clearer line: `AGENTS.md` is for project-wide things the linter cannot enforce (build, lint, naming, commit style); rationale for a specific code decision lives in a comment next to that code. Inline comments are version-controlled with the code they justify, surface in `git blame` automatically, and cannot drift because they ARE the code they explain. The trade-off is that this comment style is more terse — comments must earn their place by stating facts that aren't deducible from the code or its type signatures. Anything that reads as a lecture to future readers ("Do NOT 'fix' this back to X", "Do NOT remove this guard because Y") was dropped; if the rationale isn't self-evident from the comment alone, the reader can `git log` or read the README.

The surviving comments now state only three things that genuinely aren't visible in the code:

1. **rtk's exit-code → verdict mapping** (0/1/2/3 → allow/no-equiv/deny/ask). A reader of the code sees `spawnSync` and `result.stdout` but cannot tell what the exit codes mean — that's rtk's protocol.
2. **The "trust stdout, ignore the exit code" stance** + a one-clause rationale for why the deny verdict is not enforced ("this shim rewrites, it does not gate"). A careful reader would otherwise wonder why the code doesn't branch on `result.status`.
3. **The `// empty stdout = exit 1 or 2` inline** that ties the empty-stdout branch back to the exit-code table.

Everything else — the `excludeFromContext` guard ("`!!<cmd>` sets it; don't remove"), the closure capture's upstream contract citation, the `REWRITE_TIMEOUT_MS` purpose, the `undefined` return contract — was either obvious from type signatures and naming, or was an external coupling that risked staleness more than it gained clarity.

## What changes

* **`AGENTS.md`** — the entire `### Rewrite contract` section deleted (-44 lines). The lead paragraph "The conventions below are the ones the linter cannot enforce. They are project-wide unless noted." now flows directly into the `### Documentation` section, which was always the right place for general documentation conventions.
* **`index.ts`** — block comment above `rtkRewriteCommand` condensed from 18 lines to 3. Kept: the exit-code-verdict table, the "trust stdout / ignore exit code" stance, and the one-clause non-enforcement rationale. Dropped: the "Do NOT 'fix' this" deterrent and the deny-derivation paragraph (the latter duplicated the README). Inline `// spawn failed (...)` after `if (result.error) return undefined;` deleted as obvious from `spawnSync`'s API. Inline `// empty stdout = exit 1 or 2` kept (one line, ties to the exit-code table). The `!!<cmd>` guard comment removed (the condition name and early-return are self-documenting). The closure-capture comment referencing `pi-coding-agent` internals removed (the `_command` underscore and closure structure communicate the intent without coupling the comment to upstream file paths).

## What does **not** change

* **Runtime behavior.** `index.ts` produces the same output for the same inputs as before. `mise run check` is green.
* **The module-level JSDoc** at the top of `index.ts`. It follows the project's documentation convention ("(a) the file's role, (b) what it owns vs. what it does NOT own") and is the right home for the "rewrite shim is best-effort; `!!<cmd>` not intercepted" framing that orients new readers.
* **`AGENTS.md` Documentation, Commit messages, and Body-conventions sections.** Only the `Rewrite contract` section was removed.
* **The specs.** The behavior locked in by `document-rtk-deny-passthrough` and `cache-user-bash-rewrite` is unchanged; this PR only trims documentation density.

## Verification

* `mise run check` — `format-check`, `type-check`, `biome lint`, and `eslint .` all clean.
* Manual: read both files end-to-end. The remaining comments state only facts not deducible from the code or its type signatures.
* Manual: confirmed no external coupling introduced — no README pointer, no `AGENTS.md` cross-reference, no upstream `pi-coding-agent` file path in the surviving comments.

## Follow-ups

The two in-flight OpenSpec changes (`notify-when-rtk-unavailable`, `add-rtk-slash-command`) will follow the new comment-density convention when implemented: load-bearing rationale lands as inline comments next to the code it justifies; defensive lectures and pure restatement do not land at all.
