### PR TITLE
feat: notify the user when rtk becomes unavailable

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -23,17 +23,64 @@ import {
 
 const REWRITE_TIMEOUT_MS = 5000;
 
+type Notify = (message: string, level: "info" | "warning" | "error") => void;
+type RtkUnavailableReason = "missing" | "unexecutable";
+type SpawnErrorClassification = RtkUnavailableReason | "other";
+
+// Availability notifications are warn-once per outage: a successful rewrite
+// spawn resets the gate, and the next ENOENT/EACCES may warn again. Pi only
+// exposes the TUI notify surface through lifecycle context, so the callable is
+// captured from the first relevant event rather than at module load.
+let rtkUnavailableNotified = false;
+let cachedNotify: Notify | null = null;
+
+function alertRtkUnavailable(reason: RtkUnavailableReason): void {
+  if (rtkUnavailableNotified || cachedNotify === null) return;
+
+  const messages: Record<RtkUnavailableReason, string> = {
+    missing:
+      "[pi-rtk] rtk binary not found on PATH. Shell command rewrites are disabled. Install rtk: https://github.com/rtk-ai/rtk#installation",
+    unexecutable:
+      "[pi-rtk] rtk binary found on PATH but is not executable. Shell command rewrites are disabled. Run: chmod +x $(command -v rtk)",
+  };
+
+  rtkUnavailableNotified = true;
+  cachedNotify(messages[reason], "warning");
+}
+
+function cacheNotify(notify: Notify): void {
+  if (cachedNotify === null) cachedNotify = notify;
+}
+
+function classifySpawnError(
+  err: NodeJS.ErrnoException,
+): SpawnErrorClassification {
+  if (err.code === "ENOENT") return "missing";
+  if (err.code === "EACCES") return "unexecutable";
+
+  return "other";
+}
+
 function rtkRewriteCommand(command: string): string | undefined {
   // rtk's exit codes are permission verdicts (0/1/2/3 = allow/no-equiv/deny/
   // ask). We trust stdout and ignore the exit code. The deny verdict is
-  // intentionally not enforced — this shim rewrites, it does not gate.
+  // intentionally not enforced — this shim rewrites, it does not gate. Spawn
+  // availability errors are handled above by the transition-based notify gate.
   try {
     const result = spawnSync("rtk", ["rewrite", command], {
       encoding: "utf-8",
       timeout: REWRITE_TIMEOUT_MS,
     });
 
-    if (result.error) return undefined;
+    if (result.error) {
+      const reason = classifySpawnError(result.error);
+
+      if (reason !== "other") alertRtkUnavailable(reason);
+
+      return undefined;
+    }
+
+    rtkUnavailableNotified = false;
 
     const out = (result.stdout ?? "").trimEnd();
 
@@ -55,7 +102,23 @@ export default function (pi: ExtensionAPI) {
 
   pi.registerTool(bashTool);
 
-  pi.on("user_bash", (event) => {
+  pi.on("session_start", (_event, ctx) => {
+    cacheNotify((message, level) => ctx.ui.notify(message, level));
+
+    const result = spawnSync("rtk", ["--version"], {
+      timeout: REWRITE_TIMEOUT_MS,
+    });
+
+    if (!result.error) return;
+
+    const reason = classifySpawnError(result.error);
+
+    if (reason !== "other") alertRtkUnavailable(reason);
+  });
+
+  pi.on("user_bash", (event, ctx) => {
+    cacheNotify((message, level) => ctx.ui.notify(message, level));
+
     if (event.excludeFromContext) {
       return;
     }

--- a/openspec/changes/archive/2026-05-13-notify-when-rtk-unavailable/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-13-notify-when-rtk-unavailable/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-13

--- a/openspec/changes/archive/2026-05-13-notify-when-rtk-unavailable/design.md
+++ b/openspec/changes/archive/2026-05-13-notify-when-rtk-unavailable/design.md
@@ -1,0 +1,162 @@
+## Context
+
+`pi-rtk` is designed to fail open: if `rtk` is unavailable for any
+reason, the extension falls through and Pi runs commands unchanged.
+This is correct for resilience but it has a UX cost — a user who has
+just installed `pi-rtk` and forgotten to install `rtk` sees zero
+optimization happening and zero feedback explaining why.
+
+The fix is one targeted warn-level toast under specific, recoverable
+conditions. The design needs to thread three constraints:
+
+1. `rtkRewriteCommand` does not own a `ctx` and cannot directly
+   call `ctx.ui.notify`. A cached callable is required to bridge
+   the gap.
+2. Pi's extension lifecycle exposes `session_start`, which fires
+   once per session (startup, reload, new, resume, fork) with a
+   `ctx` parameter that includes `ctx.ui.notify`. This is the
+   documented hook for "set up initial state."
+3. The "show once" semantic the user wanted is best implemented as
+   "once per transition from working to broken," not "once
+   per Pi process," because the latter would silently swallow the
+   common case of install-then-uninstall during a long session.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detect `rtk` unavailability via ENOENT or EACCES on the same
+  `spawnSync` call that the rewrite path already uses, so there is
+  no separate detection mechanism.
+- Emit at most one warn-level notification per transition from
+  "rtk works" to "rtk does not work."
+- Use Pi's TUI notification surface (`ctx.ui.notify`) at warn
+  severity — no `console.warn`, no stderr noise.
+- Keep the user-facing message diagnosis-specific: ENOENT and
+  EACCES need different remedies.
+
+**Non-Goals:**
+
+- Differentiating timeout, EPIPE, signal interrupts, or generic
+  errors. Those remain silent fall-throughs.
+- Implementing a minimum-version probe. The existing extension
+  works against any `rtk` that responds to `rtk rewrite`.
+- Surfacing the same notification in multiple places (footer,
+  status, dialog). One toast per transition, full stop.
+- Resetting the gate on Pi restart. Each Pi process starts with a
+  fresh gate; that is intrinsic to the in-memory design.
+
+## Decisions
+
+### Decision: detect via shared `spawnSync` error code, not a separate probe
+
+When the eager probe in `session_start` runs `rtk --version`, its
+`result.error` carries the same `code` field that
+`rtkRewriteCommand`'s `spawnSync` would. We classify both call
+sites' errors with one helper and route both through one
+notification gate.
+
+Rationale: zero extra infrastructure. Both `spawnSync` errors are
+already-existing failure surfaces; this change just inspects the
+code field rather than discarding it.
+
+### Decision: re-warn on transition rather than once-per-process
+
+The notification gate (`rtkUnavailableNotified`) is reset to `false`
+whenever a `rtkRewriteCommand` `spawnSync` call returns without an
+error. The next time the spawn fails with ENOENT or EACCES, a fresh
+notification fires.
+
+Rationale: the "I uninstalled rtk and forgot" case is the most
+likely cause of a stale-warning scenario, and re-warning on the
+transition restores actionability. The state cost is one boolean
+toggle. The alternative — once-and-only-once per process — would
+silently swallow the second-uninstall case.
+
+Alternative considered: once-per-process. Rejected per above. A
+user who finds the repeated warning annoying can simply install
+`rtk` and not uninstall it.
+
+### Decision: shared flag for ENOENT and EACCES
+
+A single `rtkUnavailableNotified` boolean governs both error codes.
+Whichever condition fires first during a given transition emits its
+type-specific message and sets the flag; subsequent errors of either
+type during the same transition stay silent until a successful spawn
+resets the flag.
+
+Rationale: a user toggling between ENOENT and EACCES in one
+transition is a contrived scenario. Sharing the flag simplifies the
+state machine without losing any practically useful UX.
+
+### Decision: eager probe inside `session_start`, not `before_agent_start` or module load
+
+The eager probe is wrapped in a `pi.on("session_start", ...)`
+handler. `session_start` fires exactly once per session at startup
+(and again on reload / new / resume / fork) with `ctx` available,
+so the probe and the notify-callback capture both happen at the
+earliest opportunity without needing a guard against repeated
+invocations.
+
+Rationale: at module load (inside the default export), no `ctx` is
+available. Without `ctx`, we cannot call `ctx.ui.notify`, and the
+user explicitly does not want `console.warn`. `session_start` is
+Pi's documented hook for "session is starting; set up initial
+state."
+
+Trade-off: a user who only ever uses Pi without invoking the agent
+still receives the notification, because `session_start` fires at
+session startup regardless of whether the agent runs. That is the
+intended UX: `pi-rtk` is the user's chosen optimization layer, so
+the user should learn at session start if it is broken.
+
+Alternative considered: `before_agent_start`. Rejected because it
+fires per turn (forcing a separate `rtkEagerProbeDone` flag to
+avoid spawning `rtk --version` every turn) AND because it fires
+only on agent activity, so a user asking a non-bash question would
+get a notification about a feature they were not using at that
+moment. `session_start` fires once per session regardless of agent
+use, which both eliminates the per-turn cost and ties the
+notification to a more meaningful lifecycle moment (the session
+beginning).
+
+Alternative considered: module load. Rejected: no `ctx`.
+
+### Decision: keep all other spawn-failure modes silent
+
+Timeouts, EPIPE, signal interrupts, and unknown error codes
+continue to produce caller-invisible fall-through, matching the
+existing AGENTS.md "Rewrite contract" stance.
+
+Rationale: those failure modes are typically transient (timeout
+especially), and a sticky toast for a transient condition would
+mislead. The user explicitly scoped "rtk not available" to ENOENT
+plus EACCES.
+
+## Risks / Trade-offs
+
+- **Risk**: A user with `rtk` toggling rapidly between installed and
+  uninstalled (unusual) sees a notification on every removal. →
+  **Mitigation**: this is the desired behavior per the chosen
+  transition-based semantic. The toast is dismissible.
+
+- **Risk**: `session_start` does not fire for a Pi mode that does
+  not start a session (none currently documented). →
+  **Mitigation**: the lazy detection in `rtkRewriteCommand` and
+  the `cachedNotify` capture in the `user_bash` handler provide
+  defense in depth. Any code path that actually invokes a rewrite
+  will detect unavailability and notify.
+
+- **Risk**: `ctx.ui.notify` is unavailable in non-interactive Pi
+  modes (e.g., print mode). → **Mitigation**: the cached callable
+  is captured from `ctx.ui.notify` directly; if that surface is a
+  no-op in non-interactive modes, the notification is silently
+  dropped, which is acceptable for print mode.
+
+- **Trade-off**: two new pieces of module-level state in `index.ts`
+  (`rtkUnavailableNotified`, `cachedNotify`). Accepted because they
+  are tightly scoped, well-named, and documented in the source.
+
+- **Trade-off**: the gate-reset path runs on every successful
+  `rtkRewriteCommand` spawn (which is the common case). Cost is
+  one boolean assignment. Negligible.

--- a/openspec/changes/archive/2026-05-13-notify-when-rtk-unavailable/proposal.md
+++ b/openspec/changes/archive/2026-05-13-notify-when-rtk-unavailable/proposal.md
@@ -1,0 +1,77 @@
+## Why
+
+`pi-rtk` today fails silently when `rtk` is not on PATH or is present
+but not executable. The bash spawnHook and the `user_bash` handler
+both fall through to running the original command unchanged, which
+is the right default for resilience — but it means a user who
+installed `pi-rtk` and forgot to install `rtk` (or whose `rtk` binary
+lost its executable bit) sees no rewrites happen and has no signal
+explaining why.
+
+This change adds a single, actionable, in-band notification using
+Pi's TUI surface: when `pi-rtk` detects that `rtk` is unavailable
+(ENOENT or EACCES on spawn), the user gets a warn-level toast with
+a diagnosis and a remedy. The notification is throttled so it
+appears at most once per transition from "rtk works" to "rtk does
+not work" — a user who installs `rtk` mid-session, then uninstalls
+it again later, gets a fresh notification rather than silence.
+
+## What Changes
+
+- Add an eager probe inside a `pi.on("session_start", ...)`
+  handler. `session_start` fires once per session (startup,
+  reload, new, resume, fork) with `ctx` available. The probe
+  spawns `rtk --version`. On `ENOENT` or `EACCES`, emit a
+  warning-level notification via `ctx.ui.notify` with
+  diagnosis-specific wording.
+- Cache Pi's `ctx.ui.notify` callable at module scope from the same
+  lifecycle handler so that `rtkRewriteCommand` (which has no
+  direct `ctx` access) can emit notifications via the cached
+  callback.
+- Add lazy detection inside `rtkRewriteCommand`: when `spawnSync`
+  fails with `ENOENT` or `EACCES`, route through the same shared
+  notification gate.
+- Reset the notification gate whenever a `rtkRewriteCommand`
+  `spawnSync` call succeeds. This implements the "warn-once per
+  transition from working to broken" UX: a user who installs and
+  uninstalls `rtk` repeatedly during one Pi session receives a
+  fresh notification each time `rtk` becomes unavailable, but at
+  most one notification per such transition.
+- Use one shared flag for ENOENT and EACCES (no per-error
+  flag set). Whichever condition fires first owns the current
+  transition's notification.
+- Silence all other spawn failure modes (timeout, EPIPE, signal
+  interrupts, generic errors). They remain caller-invisible per the
+  existing fallback contract.
+
+No code behavior change beyond the notification: when `rtk` is
+available, nothing in this change has any effect; when `rtk` is
+unavailable, the existing silent fall-through continues exactly as
+before — the only addition is the at-most-one warn toast per
+transition.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None. -->
+
+### Modified Capabilities
+
+- `user-interaction`: adds a new requirement codifying the
+  warn-once-per-transition notification semantics for ENOENT and
+  EACCES on `rtk` spawn.
+
+## Impact
+
+- `index.ts`: introduces two module-scope pieces of state
+  (`rtkUnavailableNotified`, `cachedNotify`) and a notify helper;
+  adds a `session_start` handler with an eager probe; captures
+  `cachedNotify` in the `user_bash` handler as defense in depth;
+  routes spawn failures inside `rtkRewriteCommand` through the
+  shared notification gate; resets the gate on every successful
+  rewrite spawn.
+- `openspec/specs/user-interaction/spec.md`: new requirement
+  ("User Notification When rtk Is Unavailable").
+- No new dependencies. No public API change. No behavior change
+  when `rtk` is on PATH and executable.

--- a/openspec/changes/archive/2026-05-13-notify-when-rtk-unavailable/specs/user-interaction/spec.md
+++ b/openspec/changes/archive/2026-05-13-notify-when-rtk-unavailable/specs/user-interaction/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: User Notification When rtk Is Unavailable
+
+The system MUST emit at most one user-visible warning-level
+notification per transition from "rtk works" to "rtk does not work"
+within a single Pi process. The notification MUST originate from
+Pi's TUI notification surface (e.g., `ctx.ui.notify`). The
+unavailability conditions that trigger the notification MUST be
+strictly `ENOENT` (binary not on PATH) and `EACCES` (binary present
+but not executable). All other spawn-failure conditions, including
+timeout and signal interruption, MUST remain silent.
+
+#### Scenario: rtk missing at session start
+
+- **GIVEN** `rtk` is not on PATH when Pi starts
+- **WHEN** the extension receives Pi's `session_start` event
+- **THEN** the extension MUST emit one warning-level notification
+  identifying that the `rtk` binary was not found on PATH
+- **AND** the notification MUST include an actionable install
+  pointer
+
+#### Scenario: rtk missing at first user bash activity
+
+- **GIVEN** `rtk` is not on PATH when Pi starts
+- **WHEN** the user's first relevant interaction is a context-visible
+  `!<cmd>` user shell command
+- **THEN** the extension MUST emit one warning-level notification
+  identifying that the `rtk` binary was not found on PATH
+- **AND** the notification MUST include an actionable install
+  pointer
+
+#### Scenario: rtk present but not executable at session start
+
+- **GIVEN** `rtk` is on PATH but the file is not executable when
+  Pi starts
+- **WHEN** the extension receives Pi's `session_start` event
+- **THEN** the extension MUST emit one warning-level notification
+  identifying that the `rtk` binary is not executable
+- **AND** the notification MUST include an actionable remedy hint
+  (for example, a `chmod` suggestion)
+
+#### Scenario: rtk removed mid-session
+
+- **GIVEN** `rtk` was available earlier in the session and the
+  extension is in the "rtk works" state with no pending
+  notification
+- **WHEN** `rtk` becomes unavailable (uninstalled or chmod -x'd)
+  and the user invokes a shell command that triggers
+  `rtkRewriteCommand`
+- **THEN** the extension MUST emit one warning-level notification
+  describing the current unavailability condition (ENOENT or
+  EACCES) at the time of detection
+
+#### Scenario: rtk restored mid-session after a notification
+
+- **GIVEN** a notification has already fired during the current
+  unavailability transition
+- **WHEN** `rtk` becomes available again and a subsequent
+  `rtkRewriteCommand` `spawnSync` call returns without an error
+- **THEN** the extension MUST reset its notification gate so that a
+  later unavailability transition can emit a fresh notification
+
+#### Scenario: rtk uninstalled twice in one session
+
+- **GIVEN** a notification fired for an earlier unavailability
+  transition and the extension's notification gate has been reset
+  by a successful spawn in between
+- **WHEN** `rtk` becomes unavailable again
+- **THEN** the extension MUST emit one fresh warning-level
+  notification for the new unavailability transition
+
+#### Scenario: repeated unavailable spawns within one transition
+
+- **GIVEN** a notification has already fired for the current
+  unavailability transition and no successful spawn has occurred
+  since
+- **WHEN** additional `rtkRewriteCommand` invocations occur and
+  also fail with `ENOENT` or `EACCES`
+- **THEN** the extension MUST NOT emit additional notifications for
+  those repeated failures
+
+#### Scenario: non-availability spawn failures remain silent
+
+- **WHEN** a `rtkRewriteCommand` `spawnSync` call fails with a
+  reason other than `ENOENT` or `EACCES` (such as timeout, EPIPE,
+  signal interrupt, or any unknown error code)
+- **THEN** the extension MUST NOT emit a user-facing notification
+- **AND** the extension MUST continue to fall through to Pi's
+  normal shell behavior unchanged

--- a/openspec/changes/archive/2026-05-13-notify-when-rtk-unavailable/tasks.md
+++ b/openspec/changes/archive/2026-05-13-notify-when-rtk-unavailable/tasks.md
@@ -1,0 +1,37 @@
+## 1. Module state
+
+- [x] 1.1 In `index.ts`, introduce module-level state: - `rtkUnavailableNotified: boolean` (default `false`) - `cachedNotify: ((message: string, level: "info" | "warning" | "error") => void) | null` (default `null`) - A `classifySpawnError(err): "missing" | "unexecutable" | "other"` helper that maps `NodeJS.ErrnoException.code` to the three buckets.
+
+## 2. Notification helper
+
+- [x] 2.1 Add an `alertRtkUnavailable(reason: "missing" | "unexecutable")` helper that returns early when either `rtkUnavailableNotified` is true or `cachedNotify` is null. Otherwise it sets the flag to `true` and calls `cachedNotify(message, "warning")`, choosing the diagnosis-specific message from a small mapping: - `"missing"`: `[pi-rtk] rtk binary not found on PATH. Shell command rewrites are disabled. Install rtk: <link>` - `"unexecutable"`: `[pi-rtk] rtk binary found on PATH but is not executable. Shell command rewrites are disabled. Run: chmod +x $(command -v rtk)`
+
+## 3. Eager probe + ctx capture
+
+- [x] 3.1 Register a `pi.on("session_start", (_event, ctx) => { ... })` handler in the default export. Inside, call `cacheNotify` with a wrapper that calls `ctx.ui.notify(message, level)` so the notify callable is captured on the first session start.
+- [x] 3.2 In the same handler, run an eager probe by `spawnSync("rtk", ["--version"], { timeout: REWRITE_TIMEOUT_MS })`, and route its `result.error` through `classifySpawnError` → `alertRtkUnavailable(reason)`. Treat the `"other"` bucket as a no-op. `session_start` fires once per session, so no separate guard flag is needed.
+- [x] 3.3 Capture `ctx.ui.notify` in the `user_bash` handler before calling `rtkRewriteCommand`, as defense in depth so lazy ENOENT/EACCES detection still notifies if any code path reaches `rtkRewriteCommand` before `session_start` has fired.
+
+## 4. Lazy detection inside rtkRewriteCommand
+
+- [x] 4.1 Inside `rtkRewriteCommand`, when `result.error` is present, classify the error and call `alertRtkUnavailable(reason)` for the `"missing"` or `"unexecutable"` buckets only. Keep the existing `return undefined` fall-through unchanged.
+- [x] 4.2 When `result.error` is absent (the spawn succeeded), set `rtkUnavailableNotified = false` so a later transition can re-warn.
+
+## 5. Source comments
+
+- [x] 5.1 Add a short comment block above the new module-level state explaining the warn-once-per-outage semantic and why `cachedNotify` is captured from lifecycle/event context rather than at module load.
+- [x] 5.2 Cross-reference the existing exit-code-trust comment on `rtkRewriteCommand` so a reader navigating the file understands both rationales without context-switching.
+
+## 6. Specification sync
+
+- [x] 6.1 Sync the new user-notification requirement into `openspec/specs/user-interaction/spec.md`.
+
+## 7. Verification
+
+- [x] 7.1 `mise run check` passes.
+- [x] 7.2 `openspec validate notify-when-rtk-unavailable --strict` passes.
+- [x] 7.3 Manual smoke (rtk missing at start): temporarily move `rtk` off PATH, start Pi, and confirm a single warning-level toast appears at session start (no agent prompt or bash invocation required).
+- [x] 7.4 Manual smoke (rtk not executable at start): `chmod -x $(command -v rtk)`, start Pi, and confirm the EACCES variant of the toast fires once at session start. Restore with `chmod +x`.
+- [x] 7.5 Manual smoke (mid-session removal): start Pi with rtk present, run a rewrite-eligible command to confirm no toast. Then `mv $(command -v rtk) /tmp/rtk-stash`, run another rewrite-eligible command, and confirm one toast appears.
+- [x] 7.6 Manual smoke (transition re-warn): from the state in 7.5, restore rtk with `mv /tmp/rtk-stash $(command -v rtk || echo /opt/homebrew/bin/rtk)`, run a rewrite (no toast), remove again, confirm a fresh toast appears.
+- [x] 7.7 Manual smoke (other errors stay silent): no automated check practical for timeout or EPIPE. Code review confirms `"other"` bucket from `classifySpawnError` is a no-op in both call sites.

--- a/openspec/specs/user-interaction/spec.md
+++ b/openspec/specs/user-interaction/spec.md
@@ -88,3 +88,87 @@ permission extension installed by the user.
   unchanged
 - **AND** the new requirement MUST NOT alter handling of those
   verdicts
+
+### Requirement: User Notification When rtk Is Unavailable
+
+The system MUST emit at most one user-visible warning-level
+notification per transition from "rtk works" to "rtk does not work"
+within a single Pi process. The notification MUST originate from Pi's
+TUI notification surface (e.g., `ctx.ui.notify`). The unavailability
+conditions that trigger the notification MUST be strictly `ENOENT`
+(binary not on PATH) and `EACCES` (binary present but not executable).
+All other spawn-failure conditions, including timeout and signal
+interruption, MUST remain silent.
+
+#### Scenario: rtk missing at session start
+
+- **GIVEN** `rtk` is not on PATH when Pi starts
+- **WHEN** the extension receives Pi's `session_start` event
+- **THEN** the extension MUST emit one warning-level notification
+  identifying that the `rtk` binary was not found on PATH
+- **AND** the notification MUST include an actionable install pointer
+
+#### Scenario: rtk missing at first user bash activity
+
+- **GIVEN** `rtk` is not on PATH when Pi starts
+- **WHEN** the user's first relevant interaction is a context-visible
+  `!<cmd>` user shell command
+- **THEN** the extension MUST emit one warning-level notification
+  identifying that the `rtk` binary was not found on PATH
+- **AND** the notification MUST include an actionable install pointer
+
+#### Scenario: rtk present but not executable at session start
+
+- **GIVEN** `rtk` is on PATH but the file is not executable when Pi
+  starts
+- **WHEN** the extension receives Pi's `session_start` event
+- **THEN** the extension MUST emit one warning-level notification
+  identifying that the `rtk` binary is not executable
+- **AND** the notification MUST include an actionable remedy hint (for
+  example, a `chmod` suggestion)
+
+#### Scenario: rtk removed mid-session
+
+- **GIVEN** `rtk` was available earlier in the session and the
+  extension is in the "rtk works" state with no pending notification
+- **WHEN** `rtk` becomes unavailable (uninstalled or chmod -x'd) and
+  the user invokes a shell command that triggers `rtkRewriteCommand`
+- **THEN** the extension MUST emit one warning-level notification
+  describing the current unavailability condition (ENOENT or EACCES)
+  at the time of detection
+
+#### Scenario: rtk restored mid-session after a notification
+
+- **GIVEN** a notification has already fired during the current
+  unavailability transition
+- **WHEN** `rtk` becomes available again and a subsequent
+  `rtkRewriteCommand` `spawnSync` call returns without an error
+- **THEN** the extension MUST reset its notification gate so that a
+  later unavailability transition can emit a fresh notification
+
+#### Scenario: rtk uninstalled twice in one session
+
+- **GIVEN** a notification fired for an earlier unavailability
+  transition and the extension's notification gate has been reset by a
+  successful spawn in between
+- **WHEN** `rtk` becomes unavailable again
+- **THEN** the extension MUST emit one fresh warning-level notification
+  for the new unavailability transition
+
+#### Scenario: repeated unavailable spawns within one transition
+
+- **GIVEN** a notification has already fired for the current
+  unavailability transition and no successful spawn has occurred since
+- **WHEN** additional `rtkRewriteCommand` invocations occur and also
+  fail with `ENOENT` or `EACCES`
+- **THEN** the extension MUST NOT emit additional notifications for
+  those repeated failures
+
+#### Scenario: non-availability spawn failures remain silent
+
+- **WHEN** a `rtkRewriteCommand` `spawnSync` call fails with a reason
+  other than `ENOENT` or `EACCES` (such as timeout, EPIPE, signal
+  interrupt, or any unknown error code)
+- **THEN** the extension MUST NOT emit a user-facing notification
+- **AND** the extension MUST continue to fall through to Pi's normal
+  shell behavior unchanged


### PR DESCRIPTION
## Summary

`pi-rtk` was fail-open by design: when `rtk` was missing or not executable, the extension fell through to running the original command and the user got zero feedback explaining why their shell optimization wasn't happening. A user who installed `pi-rtk` and forgot to install `rtk` (or whose `rtk` binary lost its executable bit) had no in-band signal that anything was wrong. This PR adds a single, targeted, warning-level TUI toast under two specific, recoverable conditions: ENOENT (binary not on PATH) and EACCES (binary present but not executable). The toast appears at most once per outage transition. All other spawn-failure modes — timeout, EPIPE, signal interrupt, unknown errors — stay silent per the existing fall-through contract.

## Why

The motivation is one-sided in favor of feedback: a silently-broken optimization layer is a worse UX than no optimization at all, because the user doesn't know what to fix. The two failure modes addressed here are the most common and the most actionable. ENOENT means "install rtk." EACCES means "fix the executable bit." Both messages include a concrete remedy in the toast itself. Everything else (timeout, EPIPE, signals) is either transient or so unusual that a sticky warning would mislead more than help — those continue to fall through silently.

The notification design uses **transition-based gating** rather than once-per-process: each successful rewrite spawn resets the notification gate. This means a user who uninstalls `rtk`, gets a toast, reinstalls it, and then uninstalls it again will get a fresh toast on the second uninstall. The state cost is one boolean. The alternative — once-and-only-once per Pi process — would silently swallow the install-then-uninstall case, which is the exact scenario most likely to produce a stale-warning frustration.

The probe placement was the most interesting design call. An early draft bound the eager probe to `before_agent_start`, but that hook fires per turn (forcing a separate `rtkEagerProbeDone` flag) AND only on agent activity — a user asking the agent a non-bash question would get a notification about a feature they weren't using at that moment. **`session_start` was chosen instead**: it fires exactly once per session (startup / reload / new / resume / fork), with `ctx.ui.notify` available, and is Pi's documented hook for extension initial-state setup. The trade-off, written into design.md and accepted: a user who never invokes bash still receives the notification at session start. That's intentional — `pi-rtk` is the user's chosen optimization layer, so they should learn at session start if it's broken, not later when they happen to type `!ls`.

Lazy detection inside `rtkRewriteCommand` covers mid-session transitions. If `rtk` was present at session start but the user uninstalls or chmod-x's it later, the next bash rewrite call classifies the spawn error and routes through the same shared notification gate. The `user_bash` handler also captures `cachedNotify` as defense in depth, in case a future Pi runtime mode reaches `rtkRewriteCommand` before `session_start` has fired (currently impossible per Pi's documented lifecycle, but the capture is zero-cost via the `if (cachedNotify === null)` idempotency guard in `cacheNotify`).

## What changes

* **`index.ts`** — two new module-level state pieces (`rtkUnavailableNotified` boolean for the gate, `cachedNotify` for the captured TUI notify callable), an idempotent `cacheNotify` helper, a `classifySpawnError` helper that maps `NodeJS.ErrnoException.code` to `"missing" | "unexecutable" | "other"`, and an `alertRtkUnavailable` warning emitter that short-circuits when the gate is set or `cachedNotify` is null. A new `pi.on("session_start", ...)` handler captures `cachedNotify` and runs the eager `rtk --version` probe. Lazy detection added to `rtkRewriteCommand`'s `result.error` branch, plus a gate-reset on every successful spawn. The `user_bash` handler now captures `cachedNotify` as defense in depth before its `excludeFromContext` guard. The internal `Notify` type uses Pi's vocabulary (`"warning"`, not `"warn"`) so no translation layer is needed at the wrapper boundary.
* **`openspec/specs/user-interaction/spec.md`** — new requirement `User Notification When rtk Is Unavailable` with 8 scenarios: (1) rtk missing at session start; (2) rtk missing at first user-bash activity; (3) rtk present-but-unexecutable at session start; (4) rtk removed mid-session; (5) rtk restored mid-session after a notification; (6) rtk uninstalled twice in one session; (7) repeated unavailable spawns within one outage stay silent; (8) non-availability spawn failures stay silent. Synced verbatim from the change's delta.
* **`openspec/changes/archive/2026-05-13-notify-when-rtk-unavailable/`** — the completed change's proposal, design, spec delta, and task list, moved from the active changes directory after all 17 tasks were marked done (including 4 manual runtime smokes).

## What does **not** change

* **`rtkRewriteCommand`'s rewrite contract.** The function still returns `string | undefined`, still trusts stdout, still ignores rtk's exit code for the rewrite-or-not decision. The only addition is the error-classification side-effect when `result.error` is set.
* **`createBashTool({ spawnHook })` and `user_bash` rewrite semantics.** Same input → same rewrite → same execution. The `user_bash` handler does one extra cacheNotify call per invocation (idempotent, zero cost after the first).
* **The agent `bash` tool path's probe count.** `createBashTool` still spawns `rtk rewrite` exactly once per agent-issued bash command. The `cache-user-bash-rewrite` invariant is preserved.
* **No new dependencies.** No `package.json` changes.
* **Timeouts, EPIPE, signal interrupts, and unknown spawn errors** continue to fall through silently per the existing AGENTS.md "spawn-time failure" stance.

## Verification

* `mise run check` — `format-check`, `type-check`, `biome lint`, and `eslint .` all clean.
* `openspec validate notify-when-rtk-unavailable --strict` — passes (re-run after the redesign + spec sync, before the archive move).
* Manual smokes 7.3–7.6 all run successfully:
    - **rtk missing at start**: temporarily moved `rtk` off `PATH`, started Pi → ENOENT toast appeared at session start, no agent prompt needed.
    - **rtk not executable at start**: `chmod -x $(command -v rtk)`, started Pi → EACCES toast appeared at session start. Restored with `chmod +x`.
    - **mid-session removal**: started Pi with `rtk` present → no toast at session start. Removed `rtk` mid-session and invoked a rewrite-eligible command → ENOENT toast appeared from the lazy detection path.
    - **transition re-warn**: from the previous state, restored `rtk` (gate reset on next successful spawn), then removed again → fresh toast appeared.
* Code review confirms `"other"` bucket from `classifySpawnError` is a no-op at both call sites (timeout, EPIPE, etc. remain silent).

## Closes openspec change

`notify-when-rtk-unavailable`.

## Note on the design pivot during review

An earlier round of this change bound the eager probe to `before_agent_start`. Critique revealed two problems: (a) the probe ran on every agent turn unless gated by a separate flag, and (b) it fired the notification on non-bash agent activity, which felt intrusive for users asking the agent a question unrelated to shell optimization. The redesign swapped to `session_start`, which fires once per session by Pi's lifecycle guarantee and eliminates both problems. The rejected alternative is documented in `design.md` under the "Decision: eager probe inside `session_start`" entry so future contributors can see the path-not-taken and why.
