### PR TITLE
feat: add /rtk slash command, footer indicator, and session toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ User !!<cmd>
     bypass pi-rtk and use normal Pi context-excluded shell handling
 ```
 
+## `/rtk` Slash Command
+
+`pi-rtk` registers a `/rtk` slash command for session-scoped control:
+
+- `/rtk enable` turns command rewriting on for the current Pi session.
+- `/rtk disable` turns command rewriting off for the current Pi session.
+- `/rtk status` shows the current toggle state, detected `rtk` binary details, and a bypass tip.
+- `/rtk` opens an overlay where you can choose the same actions interactively.
+
+The footer includes a persistent `pi-rtk` status indicator: `rtk ✓` in green when rewriting is enabled, `rtk ✗` in red when disabled.
+
+The toggle is in-memory only. It resets to enabled every time Pi restarts and is not written to disk. For a single-command bypass while leaving the session toggle enabled, use rtk's per-command form:
+
+```shell
+!RTK_DISABLED=1 <cmd>
+```
+
 ## What pi-rtk Does Not Do
 
 `pi-rtk` is a rewrite shim. It does not gate, prompt for, sandbox, or deny commands based on their content, including when `rtk rewrite` surfaces a deny verdict.

--- a/index.ts
+++ b/index.ts
@@ -19,12 +19,25 @@ import {
   createBashTool,
   createLocalBashOperations,
   type ExtensionAPI,
+  type ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 
 const REWRITE_TIMEOUT_MS = 5000;
+const VALID_RTK_SUBCOMMANDS = ["enable", "disable", "status"] as const;
 
+// Session state is intentionally in-memory only: it resets to enabled on every
+// Pi process start and is never persisted to disk.
+let sessionEnabled = true;
+
+interface StatusReport {
+  state: string;
+  binary: string;
+  tip: string;
+}
 type Notify = (message: string, level: "info" | "warning" | "error") => void;
+type RtkSubcommand = (typeof VALID_RTK_SUBCOMMANDS)[number];
 type RtkUnavailableReason = "missing" | "unexecutable";
+
 type SpawnErrorClassification = RtkUnavailableReason | "other";
 
 // Availability notifications are warn-once per outage: a successful rewrite
@@ -61,6 +74,35 @@ function classifySpawnError(
   return "other";
 }
 
+function handleRtkSubcommand(
+  subcommand: RtkSubcommand,
+  ctx: ExtensionContext,
+): void {
+  if (subcommand === "status") {
+    showRtkStatus(ctx);
+
+    return;
+  }
+
+  setSessionEnabled(subcommand === "enable");
+  updateFooterStatus(ctx);
+  ctx.ui.notify(`pi-rtk ${subcommand}d for this session`, "info");
+}
+
+function isRtkSubcommand(value: string): value is RtkSubcommand {
+  return (VALID_RTK_SUBCOMMANDS as readonly string[]).includes(value);
+}
+
+function isSessionEnabled(): boolean {
+  return sessionEnabled;
+}
+
+function renderStatusText(ctx: ExtensionContext): string {
+  return isSessionEnabled()
+    ? ctx.ui.theme.fg("success", "rtk ✓")
+    : ctx.ui.theme.fg("error", "rtk ✗");
+}
+
 function rtkRewriteCommand(command: string): string | undefined {
   // rtk's exit codes are permission verdicts (0/1/2/3 = allow/no-equiv/deny/
   // ask). We trust stdout and ignore the exit code. The deny verdict is
@@ -90,20 +132,116 @@ function rtkRewriteCommand(command: string): string | undefined {
   }
 }
 
+function rtkStatusReport(ctx: ExtensionContext): StatusReport {
+  const state = isSessionEnabled()
+    ? ctx.ui.theme.fg("success", "enabled")
+    : ctx.ui.theme.fg("warning", "disabled");
+
+  const version = spawnSync("rtk", ["--version"], {
+    encoding: "utf-8",
+    timeout: REWRITE_TIMEOUT_MS,
+  });
+
+  let binary = "rtk not detected on PATH";
+
+  if (version.error) {
+    const reason = classifySpawnError(version.error);
+
+    if (reason !== "other") alertRtkUnavailable(reason);
+  } else {
+    rtkUnavailableNotified = false;
+
+    const path = spawnSync("sh", ["-c", "command -v rtk"], {
+      encoding: "utf-8",
+      timeout: REWRITE_TIMEOUT_MS,
+    });
+    const versionText = (version.stdout ?? "").trim() || "version unknown";
+    const pathText = (path.stdout ?? "").trim();
+
+    binary =
+      pathText.length > 0 ? `${versionText} at ${pathText}` : versionText;
+  }
+
+  return {
+    state: `Session toggle: ${state}`,
+    binary: `Binary: ${binary}`,
+    tip: "Tip: bypass rtk for one command with !RTK_DISABLED=1 <cmd>.",
+  };
+}
+
+function setSessionEnabled(enabled: boolean): void {
+  sessionEnabled = enabled;
+}
+
+async function showRtkOverlay(ctx: ExtensionContext): Promise<void> {
+  const selected = await ctx.ui.select("pi-rtk", [
+    "enable",
+    "disable",
+    "status",
+  ]);
+
+  if (selected === undefined || !isRtkSubcommand(selected)) return;
+
+  handleRtkSubcommand(selected, ctx);
+}
+
+function showRtkStatus(ctx: ExtensionContext): void {
+  const report = rtkStatusReport(ctx);
+
+  ctx.ui.notify(`${report.state}\n${report.binary}\n${report.tip}`, "info");
+}
+
+function updateFooterStatus(ctx: ExtensionContext): void {
+  ctx.ui.setStatus("pi-rtk", renderStatusText(ctx));
+}
+
 export default function (pi: ExtensionAPI) {
   const cwd = process.cwd();
   const localBashOperations = createLocalBashOperations();
 
   const bashTool = createBashTool(cwd, {
     spawnHook: ({ command, cwd, env }) => {
+      if (!isSessionEnabled()) return { command, cwd, env };
+
       return { command: rtkRewriteCommand(command) ?? command, cwd, env };
     },
   });
 
   pi.registerTool(bashTool);
+  pi.registerCommand("rtk", {
+    description: "Control pi-rtk shell command rewriting",
+    getArgumentCompletions: (prefix) => {
+      const completions = VALID_RTK_SUBCOMMANDS.filter((subcommand) =>
+        subcommand.startsWith(prefix),
+      ).map((subcommand) => ({ label: subcommand, value: subcommand }));
+
+      return completions.length > 0 ? completions : null;
+    },
+    handler: async (args, ctx) => {
+      const subcommand = args.trim();
+
+      if (subcommand.length === 0) {
+        await showRtkOverlay(ctx);
+
+        return;
+      }
+
+      if (!isRtkSubcommand(subcommand)) {
+        ctx.ui.notify(
+          "Unknown /rtk subcommand. Valid forms: /rtk enable, /rtk disable, /rtk status.",
+          "error",
+        );
+
+        return;
+      }
+
+      handleRtkSubcommand(subcommand, ctx);
+    },
+  });
 
   pi.on("session_start", (_event, ctx) => {
     cacheNotify((message, level) => ctx.ui.notify(message, level));
+    updateFooterStatus(ctx);
 
     const result = spawnSync("rtk", ["--version"], {
       timeout: REWRITE_TIMEOUT_MS,
@@ -120,6 +258,10 @@ export default function (pi: ExtensionAPI) {
     cacheNotify((message, level) => ctx.ui.notify(message, level));
 
     if (event.excludeFromContext) {
+      return;
+    }
+
+    if (!isSessionEnabled()) {
       return;
     }
 

--- a/openspec/changes/archive/2026-05-13-add-rtk-slash-command/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-13-add-rtk-slash-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-13

--- a/openspec/changes/archive/2026-05-13-add-rtk-slash-command/design.md
+++ b/openspec/changes/archive/2026-05-13-add-rtk-slash-command/design.md
@@ -1,0 +1,223 @@
+## Context
+
+`pi-rtk` today has no in-session controls: the extension is either
+loaded (and silently rewriting) or uninstalled (and not loaded). Users
+have asked for a session-scoped toggle so they can briefly turn off
+rewriting (debugging a command, testing whether rtk is the cause of
+unexpected behavior, etc.) without having to uninstall the package.
+
+Pi's `ExtensionAPI` provides three primitives that together support
+this cleanly:
+
+- `pi.registerCommand(name, { description, handler, ... })` for slash
+  commands with optional argument completions.
+- `ctx.ui.setStatus(key, text)` for a passive, single-line indicator
+  that joins other extensions' statuses in Pi's default footer.
+- `ctx.ui.select(title, items)` / `ctx.ui.notify(msg, level)` for
+  interactive and fire-and-forget UI from inside a command handler.
+
+A previous design discussion identified that `process.env.RTK_DISABLED`
+is NOT honored by rtk itself (rtk only inspects the env-prefix portion
+of the command string, not the process environment). Adopting a
+process-env contract inside `pi-rtk` would create divergence with rtk
+for zero new functionality, so this change deliberately omits process-
+env detection.
+
+A more recent merged change (`notify-when-rtk-unavailable`) introduced
+shared availability-detection infrastructure that this change can
+reuse: a `cachedNotify` module-level callable captured from
+`session_start`, a `classifySpawnError(err)` helper that maps
+`NodeJS.ErrnoException.code` to `"missing" | "unexecutable" | "other"`,
+and an `alertRtkUnavailable(reason)` gate-respecting warning emitter.
+The slash command surface should compose with that infrastructure
+rather than reinvent a parallel detection path.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give users a Pi-native, in-session, reversible way to disable
+  `pi-rtk`'s rewrite layer without uninstalling.
+- Provide an always-on footer indicator so the user can confirm
+  `pi-rtk` is loaded and what state it is in.
+- Surface a `/rtk status` view that answers "what is `pi-rtk` doing
+  right now?" without leaving the Pi session.
+- Educate users in-band about rtk's per-command `RTK_DISABLED=` bypass
+  via a static tip in `/rtk status`.
+
+**Non-Goals:**
+
+- Persisting the toggle to disk. The toggle is in-memory only and
+  resets on every Pi process start. A persistent toggle is a
+  separate feature.
+- Per-project state. The toggle is per-Pi-process, not per-repo.
+- Honoring `process.env.RTK_DISABLED`. See Context for the rationale.
+- A general `/rtk` config surface beyond enable/disable/status. The
+  bare `/rtk` overlay is a discoverability affordance, not a
+  configuration UI.
+- Surfacing rtk's deny-verdict in `/rtk status`. That belongs to the
+  `document-rtk-deny-passthrough` change; this change must not
+  contradict it.
+
+## Decisions
+
+### Decision: subcommands plus bare-form overlay
+
+Command shape: `/rtk enable`, `/rtk disable`, `/rtk status`, plus
+`/rtk` (no args) which opens a `ctx.ui.select` overlay listing the
+three actions.
+
+Rationale: subcommands are fast and scriptable for users who know
+what they want; the bare-form overlay covers discoverability ("I
+typed /rtk to see what it does"). Argument completions on the `/rtk`
+command should suggest `enable | disable | status` so tab-complete
+works.
+
+Alternatives considered:
+
+- Sibling commands (`/rtk-enable`, `/rtk-disable`, `/rtk-status`):
+  rejected — pollutes the command namespace with three entries.
+- Single toggle on bare `/rtk`: rejected — no way to query state via
+  the command, only via the footer.
+
+### Decision: in-memory state only
+
+The toggle is a module-level boolean in `index.ts`. No disk I/O, no
+config file, no env var. Reset to `true` (enabled) on every Pi
+process start.
+
+Rationale: this is the simplest implementation that satisfies the
+user need ("disable for this session"). Persistence is a separate,
+larger feature with its own UX questions (per-project? global?
+TTL?) and should not be folded in here. AGENTS.md's zero-config
+stance is preserved.
+
+### Decision: always-on footer indicator with semantic color
+
+`ctx.ui.setStatus("pi-rtk", ...)` is called on extension load and on
+every toggle. The indicator is always present, with `theme.fg("success",
+"rtk ✓")` for the enabled state and `theme.fg("error", "rtk ✗")` for the
+disabled state.
+
+Rationale: "always show" gives positive confirmation that the
+extension is loaded — a user with a long extension list benefits
+from seeing pi-rtk's presence in the footer regardless of state.
+Dim styling keeps the enabled indicator unobtrusive.
+
+Alternatives considered:
+
+- Show only when disabled ("notable only"): rejected — loses the
+  load-time confirmation benefit.
+- Full footer takeover via `ctx.ui.setFooter`: rejected — would
+  conflict with footer extensions like `pi-powerline-footer`.
+
+### Decision: do not detect process.env.RTK_DISABLED
+
+The extension does not read `process.env.RTK_DISABLED` and does not
+adjust behavior based on it.
+
+Rationale: rtk's own contract for `RTK_DISABLED` is strictly
+per-command env-prefix (`RTK_DISABLED=1 git status`). The process
+env var has no effect inside rtk. Inventing process-env semantics
+in `pi-rtk` would create two mechanisms with the same name and
+different scopes, surprising users familiar with rtk's contract.
+All three disable use cases are already addressed:
+
+- Per command: rtk handles `RTK_DISABLED=<any> <cmd>` natively.
+- This session: the new `/rtk disable` slash command.
+- Permanent: `pi remove npm:@sherif-fanous/pi-rtk`.
+
+### Decision: include a static educational tip in `/rtk status`
+
+`/rtk status` includes a one-line tip mentioning the per-command form
+(`!RTK_DISABLED=1 <cmd>`). The tip is static text — no env inspection,
+no state.
+
+Rationale: surfaces a useful but obscure rtk feature where users are
+already looking for "how do I disable rtk?". Avoids the failure mode
+where users find the README-only documentation, learn about
+`/rtk disable`, and never discover the per-command form.
+
+### Decision: toggle short-circuits BEFORE the rtk subprocess
+
+When disabled, the gate skips the `rtkRewriteCommand` call entirely
+in both the `bash` `spawnHook` and the `user_bash` handler. No `rtk`
+subprocess is spawned.
+
+Rationale: disabling rtk should also remove its observable cost
+(spawn latency). The orthogonality scenario between session toggle
+and per-command `RTK_DISABLED=` prefix is preserved: when the session
+is enabled and a command carries the per-command prefix, the call
+proceeds to rtk and rtk itself bails on the prefix detection.
+
+### Decision: slash command handlers do NOT capture `cachedNotify`
+
+The `/rtk` slash command handler will not call `cacheNotify(...)` to
+capture `ctx.ui.notify`. Pi's lifecycle guarantees that
+`session_start` fires before any user-initiated slash command, and
+`session_start` is where `cachedNotify` gets captured. Slash command
+handlers therefore can either (a) use `ctx.ui.notify` directly for
+their own user-facing output (the normal pattern) or (b) trust that
+other code paths that go through `alertRtkUnavailable` will already
+find `cachedNotify` populated.
+
+Rationale: avoids a third call site for the same `cacheNotify` pattern
+and keeps the "notify-capture lives in `session_start`" mental model
+intact. The defense-in-depth capture in the `user_bash` handler exists
+specifically because `user_bash` could in principle fire before any
+first-class session lifecycle hook in a hypothetical future Pi runtime
+mode; the slash command handler has no such concern because slash
+commands fundamentally cannot be issued before a session is active.
+
+### Decision: `/rtk status` reuses the existing availability gate
+
+The `statusReport()` function spawns `rtk --version` to render the
+binary version and path. When that spawn fails with `ENOENT` or
+`EACCES`, the function MUST classify the error via
+`classifySpawnError` and call `alertRtkUnavailable(reason)`, then
+render an "rtk not detected" (or equivalent) line in the status
+output. The output line shown to the user is independent of the
+notification: the user sees the diagnosis in the status view AND, if
+the outage gate is open, gets the toast.
+
+Rationale: the status command is the most likely surface where a user
+will discover that rtk is broken, so triggering the standard
+notification path keeps the warning-once-per-outage semantic intact
+without the user needing to do anything else. The gate-respecting
+check inside `alertRtkUnavailable` ensures no duplicate toast if a
+notification already fired during the same outage.
+
+Alternative considered: status-only diagnosis (no notification
+side-effect). Rejected because it would split availability awareness
+into two parallel mechanisms (toast for spawn-driven detection,
+status-line for slash-command detection) and lose the
+warning-once-per-outage gate's authority over the slash command
+surface.
+
+## Risks / Trade-offs
+
+- **Risk**: User toggles `/rtk disable`, expects it to persist across
+  Pi restarts, and is surprised when the next session starts with
+  rewrites on. → **Mitigation**: README and `/rtk status` make clear
+  that the toggle is session-scoped. If persistence becomes a real
+  ask, propose it as a separate change.
+
+- **Risk**: Always-on footer indicator competes for footer space with
+  other extensions a user runs. → **Mitigation**: use `setStatus`
+  (not `setFooter`) so Pi's default footer aggregator handles
+  layout. Keep the text short (`rtk ✓` enabled, `rtk ✗`
+  disabled). Color carries the semantic (success / error); the
+  symbols provide a colorblind-safe textual cue.
+
+- **Risk**: User mis-types `/rtk disabled` instead of `/rtk disable`.
+  → **Mitigation**: `getArgumentCompletions` returns the three valid
+  subcommands; unknown args trigger a `ctx.ui.notify` error with
+  the list of valid forms. Do NOT silently treat unknown args as
+  no-op.
+
+- **Trade-off**: A `/rtk status` that includes the per-command tip
+  is one line noisier than a pure state report. Accepted because
+  in-band discoverability is genuinely valuable here.
+
+- **Trade-off**: The toggle gate adds a single boolean check per
+  bash command. Negligible cost.

--- a/openspec/changes/archive/2026-05-13-add-rtk-slash-command/proposal.md
+++ b/openspec/changes/archive/2026-05-13-add-rtk-slash-command/proposal.md
@@ -1,0 +1,75 @@
+## Why
+
+`pi-rtk` today is a load-it-or-uninstall-it extension: there is no
+in-session way to turn the rewrite layer off, query what it is doing,
+or confirm that it is loaded. The only existing bypass is rtk's own
+per-command `RTK_DISABLED=1 <cmd>` env-prefix, which works fine
+for one-off bypasses but does not address the common case of "I want
+to disable rtk for the rest of this session and re-enable it later."
+
+Adding a `/rtk` slash command and an always-on footer indicator gives
+users a Pi-native, reversible, in-session toggle plus a persistent
+visual confirmation that `pi-rtk` is loaded. It also creates a
+discoverable surface for future state (the spec keeps the surface
+minimal for now: enable, disable, status, plus a bare-form overlay
+for discoverability).
+
+## What Changes
+
+- Register a `/rtk` slash command via `pi.registerCommand`, with
+  subcommands `enable`, `disable`, `status`, and a bare invocation
+  (`/rtk` with no args) that opens a settings overlay via
+  `ctx.ui.select`.
+- Maintain an in-memory session toggle. Default is enabled. The
+  toggle is reset to enabled on every Pi process start (no
+  persistence to disk).
+- When the toggle is `disabled`, both the agent `bash` `spawnHook`
+  and the `user_bash` handler MUST bypass `rtk rewrite` entirely
+  (no spawn) and fall through to the original command.
+- Show a persistent footer indicator via `ctx.ui.setStatus("pi-rtk",
+...)`. Always-on: dim styling for the enabled (default) state,
+  warn styling for the disabled state. Indicator updates immediately
+  on toggle.
+- `/rtk status` output includes (a) current session state, (b)
+  detected `rtk` binary version and path, and (c) a one-line
+  educational tip about rtk's per-command `!RTK_DISABLED=1 <cmd>`
+  bypass. The tip is purely static help text — the extension does
+  not inspect any environment variable.
+- Explicitly do not honor `process.env.RTK_DISABLED`. rtk itself does
+  not honor it; adopting a process-env contract here would diverge
+  from rtk without adding behavior that is not already covered by
+  the session toggle or the per-command prefix.
+
+No removals. No breaking changes to existing behavior — the toggle
+defaults to enabled, so users who do not invoke `/rtk` see no
+behavioral change.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None. All requirements attach to existing capabilities. -->
+
+### Modified Capabilities
+
+- `infrastructure`: adds requirement for `/rtk` slash command
+  registration as a new extension surface.
+- `shell-optimization`: adds requirement that the session toggle
+  short-circuits the rewrite path before any `rtk` subprocess is
+  spawned, with explicit orthogonality against rtk's per-command
+  `RTK_DISABLED=` env prefix.
+- `user-interaction`: adds requirements for the session toggle's
+  user-facing semantics, the persistent footer indicator, and the
+  `/rtk status` output (including the static educational tip about
+  rtk's per-command bypass).
+
+## Impact
+
+- `index.ts`: introduces module-level toggle state, registers the
+  `/rtk` slash command, installs the footer status, and gates both
+  call sites of `rtkRewriteCommand` on the toggle.
+- `README.md`: new section documenting `/rtk`, its subcommands, and
+  the footer indicator.
+- `package.json`: no new dependencies.
+- No API breakage. Existing callers see no behavior change while the
+  toggle remains in its default enabled state.

--- a/openspec/changes/archive/2026-05-13-add-rtk-slash-command/specs/infrastructure/spec.md
+++ b/openspec/changes/archive/2026-05-13-add-rtk-slash-command/specs/infrastructure/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: /rtk Slash Command Registration
+
+The extension MUST register a `/rtk` slash command via Pi's
+`registerCommand` API on load. The command MUST accept the
+subcommand arguments `enable`, `disable`, and `status`, and MUST
+support a bare invocation with no arguments.
+
+#### Scenario: extension registers /rtk at load
+
+- **WHEN** Pi loads the `pi-rtk` extension
+- **THEN** `/rtk` MUST appear in Pi's slash command registry with a
+  human-readable description
+- **AND** invoking `/rtk` MUST route to the extension's handler
+
+#### Scenario: argument completion lists valid subcommands
+
+- **WHEN** the user types `/rtk ` and triggers argument completion
+- **THEN** Pi MUST offer `enable`, `disable`, and `status` as the
+  available completions
+
+#### Scenario: unknown subcommand is rejected
+
+- **WHEN** the user invokes `/rtk` with an argument that is not
+  `enable`, `disable`, or `status`
+- **THEN** the extension MUST surface a user-facing error message
+  listing the valid subcommands
+- **AND** the session toggle state MUST NOT change

--- a/openspec/changes/archive/2026-05-13-add-rtk-slash-command/specs/shell-optimization/spec.md
+++ b/openspec/changes/archive/2026-05-13-add-rtk-slash-command/specs/shell-optimization/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Session Toggle Gates Rewrite Attempt
+
+When the session toggle is in the `disabled` state, the system MUST
+NOT call `rtk rewrite` for any shell command, regardless of execution
+path (agent `bash` tool, user `!<cmd>` shell). When the toggle is in
+the `enabled` state, existing rewrite behavior MUST continue
+unchanged.
+
+#### Scenario: agent bash with toggle disabled
+
+- **WHEN** the session toggle is `disabled`
+- **AND** the agent invokes the `bash` tool with a shell command
+- **THEN** the extension MUST NOT spawn `rtk rewrite`
+- **AND** the original command MUST execute through Pi's normal
+  shell behavior
+
+#### Scenario: user !<cmd> with toggle disabled
+
+- **WHEN** the session toggle is `disabled`
+- **AND** the user executes a context-visible shell command via
+  Pi's `!<cmd>` syntax
+- **THEN** the extension MUST NOT spawn `rtk rewrite`
+- **AND** the command MUST execute through Pi's normal user shell
+  path
+
+#### Scenario: toggle enabled preserves existing rewrite behavior
+
+- **WHEN** the session toggle is `enabled` (the default)
+- **AND** a shell command is submitted via the agent `bash` tool or
+  user `!<cmd>` syntax
+- **THEN** the existing rewrite, fall-through, and timeout behavior
+  MUST apply unchanged
+
+### Requirement: Toggle Composes With Per-Command Bypass
+
+The extension MUST treat the session toggle and rtk's per-command
+env-prefix bypass (commands beginning with `RTK_DISABLED=`) as
+orthogonal concerns. The session toggle controls whether `pi-rtk`
+calls `rtk rewrite` at all. The per-command env-prefix controls
+whether `rtk rewrite`, once called, produces a rewrite for that
+specific command. Neither mechanism MUST short-circuit the other.
+
+#### Scenario: enabled toggle plus per-command prefix
+
+- **WHEN** the session toggle is `enabled`
+- **AND** the command is `RTK_DISABLED=1 git status`
+- **THEN** `pi-rtk` MUST call `rtk rewrite` as normal
+- **AND** `rtk rewrite` is expected to return no rewrite due to the
+  env prefix
+- **AND** the original command MUST execute through Pi's normal
+  shell behavior
+
+#### Scenario: disabled toggle short-circuits regardless of prefix
+
+- **WHEN** the session toggle is `disabled`
+- **AND** the command is `RTK_DISABLED=1 git status` or any other
+  command
+- **THEN** the extension MUST NOT spawn `rtk rewrite`
+- **AND** the original command MUST execute through Pi's normal
+  shell behavior

--- a/openspec/changes/archive/2026-05-13-add-rtk-slash-command/specs/user-interaction/spec.md
+++ b/openspec/changes/archive/2026-05-13-add-rtk-slash-command/specs/user-interaction/spec.md
@@ -1,0 +1,97 @@
+## ADDED Requirements
+
+### Requirement: Session-Scoped Rewrite Toggle
+
+The extension MUST expose an in-memory, session-scoped toggle that
+controls whether `pi-rtk` performs rewrites. The toggle's default
+state MUST be `enabled`. The toggle MUST reset to `enabled` on every
+Pi process start. The toggle MUST NOT be persisted to disk.
+
+#### Scenario: /rtk disable turns the toggle off
+
+- **GIVEN** the session toggle is in any state
+- **WHEN** the user invokes `/rtk disable`
+- **THEN** the toggle MUST transition to `disabled`
+- **AND** the extension MUST surface a user-facing confirmation
+- **AND** the footer indicator MUST update to reflect the disabled
+  state
+
+#### Scenario: /rtk enable turns the toggle on
+
+- **GIVEN** the session toggle is in any state
+- **WHEN** the user invokes `/rtk enable`
+- **THEN** the toggle MUST transition to `enabled`
+- **AND** the extension MUST surface a user-facing confirmation
+- **AND** the footer indicator MUST update to reflect the enabled
+  state
+
+#### Scenario: toggle resets on new Pi process
+
+- **WHEN** Pi exits and is launched again
+- **THEN** the session toggle MUST start in the `enabled` state
+- **AND** no toggle state MUST be read from disk
+
+### Requirement: Persistent Footer State Indicator
+
+The extension MUST register a single footer status entry via
+`ctx.ui.setStatus("pi-rtk", ...)` and MUST keep that entry present
+for the lifetime of the extension. The entry MUST visually
+differentiate the `enabled` and `disabled` states. The entry MUST
+update immediately when the session toggle changes.
+
+#### Scenario: indicator present on load
+
+- **WHEN** the `pi-rtk` extension is loaded by Pi
+- **THEN** the footer MUST display a `pi-rtk` status entry
+- **AND** the entry MUST reflect the `enabled` default state
+
+#### Scenario: indicator updates on toggle
+
+- **GIVEN** the footer is displaying the `pi-rtk` status entry in
+  the `enabled` style
+- **WHEN** the user invokes `/rtk disable`
+- **THEN** the footer entry MUST transition to a visually distinct
+  `disabled` style
+
+### Requirement: /rtk Bare Invocation Opens Settings Overlay
+
+The extension MUST treat the bare `/rtk` invocation (no arguments)
+as a request for a settings overlay. The overlay MUST allow the user
+to select among the same actions exposed by the subcommands.
+
+#### Scenario: bare /rtk opens overlay
+
+- **WHEN** the user invokes `/rtk` with no arguments
+- **THEN** the extension MUST display an interactive selection
+  overlay listing at least `enable`, `disable`, and `status`
+- **AND** selecting an item MUST execute the corresponding action
+- **AND** dismissing the overlay MUST NOT change any state
+
+### Requirement: /rtk Status Report
+
+`/rtk status` MUST report the current session toggle state and the
+detected `rtk` binary identity, and MUST include a static
+educational tip about rtk's per-command `!RTK_DISABLED=1 <cmd>`
+bypass. The tip MUST be plain documentation text — the extension
+MUST NOT read environment variables when producing the status
+report.
+
+#### Scenario: status reports current state
+
+- **WHEN** the user invokes `/rtk status`
+- **THEN** the output MUST identify the current session toggle
+  state (`enabled` or `disabled`)
+- **AND** the output MUST identify the detected `rtk` binary
+  version and path, or MUST clearly indicate when `rtk` is not on
+  PATH
+- **AND** the output MUST include a one-line tip mentioning the
+  per-command `!RTK_DISABLED=1 <cmd>` bypass
+
+#### Scenario: status does not inspect process environment
+
+- **WHEN** the user invokes `/rtk status`
+- **THEN** the extension MUST NOT read `process.env.RTK_DISABLED`
+  or any other process environment variable as part of building
+  the status output
+- **AND** the per-command tip MUST appear regardless of the host
+  environment

--- a/openspec/changes/archive/2026-05-13-add-rtk-slash-command/tasks.md
+++ b/openspec/changes/archive/2026-05-13-add-rtk-slash-command/tasks.md
@@ -1,0 +1,117 @@
+## 1. Module state
+
+- [x] 1.1 Add a module-level mutable boolean `sessionEnabled` in
+      `index.ts`, defaulting to `true`. Add a typed getter and a
+      setter that the slash command handlers can call. Document
+      that this state is intentionally in-memory only.
+
+## 2. Slash command
+
+- [x] 2.1 Register `/rtk` via `pi.registerCommand` inside the
+      default export. Provide a short description and
+      `getArgumentCompletions` returning `enable`, `disable`, and
+      `status`.
+- [x] 2.2 Implement the handler dispatch: route `enable`,
+      `disable`, and `status` to dedicated functions; route the
+      bare invocation (no args) to a `ctx.ui.select` overlay
+      listing the three actions.
+- [x] 2.3 Reject unknown subcommands with a `ctx.ui.notify` error
+      message listing the valid forms. Do not change toggle state
+      on rejection.
+
+## 3. Footer indicator
+
+- [x] 3.1 On extension load, call `ctx.ui.setStatus("pi-rtk", ...)`
+      with the enabled-state text. Re-render the indicator whenever
+      the toggle changes. Use `theme.fg("success", "rtk ✓")` for
+      enabled and `theme.fg("error", "rtk ✗")` for disabled. The Pi
+      `setStatus` API is fire-and-forget; no explicit teardown
+      required.
+      NOTE: `setStatus` is exposed on `ctx.ui` inside command
+      handlers; if extension-load has no `ctx`, set the initial
+      status on the first handler invocation or via the relevant
+      lifecycle hook in `ExtensionAPI`.
+
+## 4. Rewrite gating
+
+- [x] 4.1 In the `createBashTool` `spawnHook`, short-circuit when
+      `sessionEnabled === false`: return `{ command, cwd, env }`
+      unchanged without calling `rtkRewriteCommand`.
+- [x] 4.2 In the `user_bash` handler, short-circuit when
+      `sessionEnabled === false`: return without claiming the
+      event so Pi's normal user-bash path runs the command
+      unchanged.
+- [x] 4.3 Verify both call sites still respect the existing
+      `excludeFromContext` guard in `user_bash` (i.e., the
+      `excludeFromContext` early-return MUST come before the
+      toggle check).
+
+## 5. /rtk status output
+
+- [x] 5.1 Implement `statusReport()` that returns a structured
+      report containing: (a) current session state with the
+      enabled/disabled style indicator, (b) `rtk` binary version
+      and path obtained via a bounded `rtk --version` subprocess
+      call, gracefully degrading to a clear "rtk not detected"
+      message on spawn failure, (c) a static one-line tip about
+      the per-command `!RTK_DISABLED=1 <cmd>` bypass.
+- [x] 5.2 When the `rtk --version` spawn fails inside
+      `statusReport()`, classify the error via the existing
+      `classifySpawnError` helper from
+      `notify-when-rtk-unavailable` and call
+      `alertRtkUnavailable(reason)` for `"missing"` or
+      `"unexecutable"` so the standard warning-once-per-outage
+      gate also covers the slash command surface. The
+      `alertRtkUnavailable` gate already prevents duplicate
+      toasts within the same outage.
+- [x] 5.3 Render via `ctx.ui.notify` as a multi-line info-level
+      message. The handler MUST NOT read any environment variable
+      to produce the tip line.
+- [x] 5.4 Do NOT add a `cacheNotify` call inside any `/rtk`
+      handler. Pi's lifecycle guarantees `session_start` fires
+      before any slash command, and `session_start` already
+      captures `cachedNotify`. Slash command handlers use
+      `ctx.ui.notify` directly for their own UI output.
+
+## 6. README
+
+- [x] 6.1 Add a new section documenting the `/rtk` slash command,
+      its subcommands, the bare-form overlay, and the footer
+      indicator. Place it after the existing `User !!<cmd>`
+      section and before the `What pi-rtk Does Not Do` section
+      from the `document-rtk-deny-passthrough` change.
+- [x] 6.2 In the same section, explicitly call out that the
+      toggle is session-scoped and resets on Pi restart, and link
+      to rtk's per-command `RTK_DISABLED=` form as the
+      complementary single-command bypass.
+
+## 7. Specification sync
+
+- [x] 7.1 Sync the four spec deltas to the main specs (these are
+      additive; copy each requirement block from the change's
+      delta into the corresponding main spec): - `openspec/changes/add-rtk-slash-command/specs/infrastructure/spec.md`
+      → `openspec/specs/infrastructure/spec.md` - `openspec/changes/add-rtk-slash-command/specs/shell-optimization/spec.md`
+      → `openspec/specs/shell-optimization/spec.md` - `openspec/changes/add-rtk-slash-command/specs/user-interaction/spec.md`
+      → `openspec/specs/user-interaction/spec.md`
+
+## 8. Verification
+
+- [x] 8.1 `mise run check` passes (format-check, type-check, lint).
+- [x] 8.2 `openspec validate add-rtk-slash-command --strict`
+      passes.
+- [x] 8.3 Diff the change's spec deltas against the corresponding
+      main spec sections after sync; confirm scenarios are
+      identical (same titles, same order, same wording).
+- [ ] 8.4 Manual smoke: load extension, observe footer indicator;
+      run `/rtk` (overlay), `/rtk status`, `/rtk disable`,
+      `/rtk enable`, `/rtk garbage` (error path); confirm an agent
+      bash call after `/rtk disable` does NOT spawn `rtk` (e.g.
+      via `RTK_LOG`-style instrumentation or `dtruss`/`strace`).
+- [ ] 8.5 Manual orthogonality smoke: with toggle enabled, run
+      `!RTK_DISABLED=1 git status` via Pi — rtk should be called,
+      see its prefix, and bail.
+- [ ] 8.6 Manual smoke (unavailability integration): with toggle
+      enabled and rtk missing, run `/rtk status` and confirm both
+      (a) the status output reports "rtk not detected" and (b)
+      the standard ENOENT warning toast fires (unless the gate
+      already closed earlier in the session).

--- a/openspec/specs/infrastructure/spec.md
+++ b/openspec/specs/infrastructure/spec.md
@@ -6,6 +6,34 @@ Define how `pi-rtk` integrates with Pi as an installable package that provides a
 
 ## Requirements
 
+### Requirement: /rtk Slash Command Registration
+
+The extension MUST register a `/rtk` slash command via Pi's
+`registerCommand` API on load. The command MUST accept the
+subcommand arguments `enable`, `disable`, and `status`, and MUST
+support a bare invocation with no arguments.
+
+#### Scenario: extension registers /rtk at load
+
+- **WHEN** Pi loads the `pi-rtk` extension
+- **THEN** `/rtk` MUST appear in Pi's slash command registry with a
+  human-readable description
+- **AND** invoking `/rtk` MUST route to the extension's handler
+
+#### Scenario: argument completion lists valid subcommands
+
+- **WHEN** the user types `/rtk ` and triggers argument completion
+- **THEN** Pi MUST offer `enable`, `disable`, and `status` as the
+  available completions
+
+#### Scenario: unknown subcommand is rejected
+
+- **WHEN** the user invokes `/rtk` with an argument that is not
+  `enable`, `disable`, or `status`
+- **THEN** the extension MUST surface a user-facing error message
+  listing the valid subcommands
+- **AND** the session toggle state MUST NOT change
+
 ### Requirement: Bash Tool Integration
 
 The system MUST provide a `bash` tool implementation that Pi uses when the `pi-rtk` package is loaded.

--- a/openspec/specs/shell-optimization/spec.md
+++ b/openspec/specs/shell-optimization/spec.md
@@ -83,6 +83,67 @@ The system MUST NOT apply `pi-rtk` optimization to user shell commands whose out
 - **THEN** `pi-rtk` MUST NOT intercept the command for optimization
 - **AND** Pi MUST handle execution using its normal context-excluded shell behavior
 
+### Requirement: Session Toggle Gates Rewrite Attempt
+
+When the session toggle is in the `disabled` state, the system MUST
+NOT call `rtk rewrite` for any shell command, regardless of execution
+path (agent `bash` tool, user `!<cmd>` shell). When the toggle is in
+the `enabled` state, existing rewrite behavior MUST continue
+unchanged.
+
+#### Scenario: agent bash with toggle disabled
+
+- **WHEN** the session toggle is `disabled`
+- **AND** the agent invokes the `bash` tool with a shell command
+- **THEN** the extension MUST NOT spawn `rtk rewrite`
+- **AND** the original command MUST execute through Pi's normal
+  shell behavior
+
+#### Scenario: user !<cmd> with toggle disabled
+
+- **WHEN** the session toggle is `disabled`
+- **AND** the user executes a context-visible shell command via
+  Pi's `!<cmd>` syntax
+- **THEN** the extension MUST NOT spawn `rtk rewrite`
+- **AND** the command MUST execute through Pi's normal user shell
+  path
+
+#### Scenario: toggle enabled preserves existing rewrite behavior
+
+- **WHEN** the session toggle is `enabled` (the default)
+- **AND** a shell command is submitted via the agent `bash` tool or
+  user `!<cmd>` syntax
+- **THEN** the existing rewrite, fall-through, and timeout behavior
+  MUST apply unchanged
+
+### Requirement: Toggle Composes With Per-Command Bypass
+
+The extension MUST treat the session toggle and rtk's per-command
+env-prefix bypass (commands beginning with `RTK_DISABLED=`) as
+orthogonal concerns. The session toggle controls whether `pi-rtk`
+calls `rtk rewrite` at all. The per-command env-prefix controls
+whether `rtk rewrite`, once called, produces a rewrite for that
+specific command. Neither mechanism MUST short-circuit the other.
+
+#### Scenario: enabled toggle plus per-command prefix
+
+- **WHEN** the session toggle is `enabled`
+- **AND** the command is `RTK_DISABLED=1 git status`
+- **THEN** `pi-rtk` MUST call `rtk rewrite` as normal
+- **AND** `rtk rewrite` is expected to return no rewrite due to the
+  env prefix
+- **AND** the original command MUST execute through Pi's normal
+  shell behavior
+
+#### Scenario: disabled toggle short-circuits regardless of prefix
+
+- **WHEN** the session toggle is `disabled`
+- **AND** the command is `RTK_DISABLED=1 git status` or any other
+  command
+- **THEN** the extension MUST NOT spawn `rtk rewrite`
+- **AND** the original command MUST execute through Pi's normal
+  shell behavior
+
 ### Requirement: Single Rewrite Per Intercepted User Bash Event
 
 The system MUST issue at most one `rtk rewrite` subprocess

--- a/openspec/specs/user-interaction/spec.md
+++ b/openspec/specs/user-interaction/spec.md
@@ -64,6 +64,102 @@ The system MUST keep user bash optimization non-disruptive during normal operati
 - **THEN** the command MUST complete without requiring additional user interaction solely for optimization reporting
 - **AND** the user experience MUST remain consistent with normal shell execution
 
+### Requirement: Session-Scoped Rewrite Toggle
+
+The extension MUST expose an in-memory, session-scoped toggle that
+controls whether `pi-rtk` performs rewrites. The toggle's default
+state MUST be `enabled`. The toggle MUST reset to `enabled` on every
+Pi process start. The toggle MUST NOT be persisted to disk.
+
+#### Scenario: /rtk disable turns the toggle off
+
+- **GIVEN** the session toggle is in any state
+- **WHEN** the user invokes `/rtk disable`
+- **THEN** the toggle MUST transition to `disabled`
+- **AND** the extension MUST surface a user-facing confirmation
+- **AND** the footer indicator MUST update to reflect the disabled
+  state
+
+#### Scenario: /rtk enable turns the toggle on
+
+- **GIVEN** the session toggle is in any state
+- **WHEN** the user invokes `/rtk enable`
+- **THEN** the toggle MUST transition to `enabled`
+- **AND** the extension MUST surface a user-facing confirmation
+- **AND** the footer indicator MUST update to reflect the enabled
+  state
+
+#### Scenario: toggle resets on new Pi process
+
+- **WHEN** Pi exits and is launched again
+- **THEN** the session toggle MUST start in the `enabled` state
+- **AND** no toggle state MUST be read from disk
+
+### Requirement: Persistent Footer State Indicator
+
+The extension MUST register a single footer status entry via
+`ctx.ui.setStatus("pi-rtk", ...)` and MUST keep that entry present
+for the lifetime of the extension. The entry MUST visually
+differentiate the `enabled` and `disabled` states. The entry MUST
+update immediately when the session toggle changes.
+
+#### Scenario: indicator present on load
+
+- **WHEN** the `pi-rtk` extension is loaded by Pi
+- **THEN** the footer MUST display a `pi-rtk` status entry
+- **AND** the entry MUST reflect the `enabled` default state
+
+#### Scenario: indicator updates on toggle
+
+- **GIVEN** the footer is displaying the `pi-rtk` status entry in
+  the `enabled` style
+- **WHEN** the user invokes `/rtk disable`
+- **THEN** the footer entry MUST transition to a visually distinct
+  `disabled` style
+
+### Requirement: /rtk Bare Invocation Opens Settings Overlay
+
+The extension MUST treat the bare `/rtk` invocation (no arguments)
+as a request for a settings overlay. The overlay MUST allow the user
+to select among the same actions exposed by the subcommands.
+
+#### Scenario: bare /rtk opens overlay
+
+- **WHEN** the user invokes `/rtk` with no arguments
+- **THEN** the extension MUST display an interactive selection
+  overlay listing at least `enable`, `disable`, and `status`
+- **AND** selecting an item MUST execute the corresponding action
+- **AND** dismissing the overlay MUST NOT change any state
+
+### Requirement: /rtk Status Report
+
+`/rtk status` MUST report the current session toggle state and the
+detected `rtk` binary identity, and MUST include a static
+educational tip about rtk's per-command `!RTK_DISABLED=1 <cmd>`
+bypass. The tip MUST be plain documentation text — the extension
+MUST NOT read environment variables when producing the status
+report.
+
+#### Scenario: status reports current state
+
+- **WHEN** the user invokes `/rtk status`
+- **THEN** the output MUST identify the current session toggle
+  state (`enabled` or `disabled`)
+- **AND** the output MUST identify the detected `rtk` binary
+  version and path, or MUST clearly indicate when `rtk` is not on
+  PATH
+- **AND** the output MUST include a one-line tip mentioning the
+  per-command `!RTK_DISABLED=1 <cmd>` bypass
+
+#### Scenario: status does not inspect process environment
+
+- **WHEN** the user invokes `/rtk status`
+- **THEN** the extension MUST NOT read `process.env.RTK_DISABLED`
+  or any other process environment variable as part of building
+  the status output
+- **AND** the per-command tip MUST appear regardless of the host
+  environment
+
 ### Requirement: No Refusal On rtk Permission Verdict
 
 The system MUST NOT refuse to execute a shell command based on a


### PR DESCRIPTION
## Summary

`pi-rtk` previously had no in-session controls: it was either loaded and silently rewriting, or uninstalled entirely. A user wanting to briefly disable rewriting — to debug a command, test whether rtk was the cause of unexpected behavior, or run a one-off without going through rtk — had to uninstall the package. The only finer-grained bypass was rtk's per-command `!RTK_DISABLED=1 <cmd>` env prefix, which works for one command but not for the rest of a session. This PR adds a Pi-native `/rtk` slash command, a persistent footer indicator, and a session-scoped toggle so the rewriting layer is both **visible** and **reversibly controllable** from inside Pi.

## Why

Three intertwined motivations:

1. **Discoverable reversible control.** Slash commands are Pi's idiomatic surface for "thing I want to do interactively right now." A `/rtk disable` toggle is faster than uninstalling and reinstalling the package when debugging, and the slash command is documented through Pi's command system so it surfaces automatically in `/commands` and tab-completion. The bare `/rtk` invocation opens a `ctx.ui.select` overlay for users who don't remember the subcommand name.

2. **Ambient state visibility.** Without a footer indicator, a user who has toggled rewriting off has no way to see it from looking at Pi. A persistent indicator (`rtk ✓` when enabled, `rtk ✗` when disabled, with semantic green/red coloring) means the state is always one glance away. The `setStatus` API — rather than the heavier `setFooter` — lets Pi's default footer aggregator handle layout, so the indicator composes with other footer-style extensions like `pi-powerline-footer` rather than fighting them.

3. **In-band rtk diagnosis.** `/rtk status` collapses three pieces of useful information into one command: the current toggle state, the detected rtk binary version + path, and a tip for the per-command bypass. The status report also routes any `rtk --version` spawn failures through the existing `classifySpawnError` + `alertRtkUnavailable` infrastructure from the `notify-when-rtk-unavailable` change, so a user discovering "rtk is broken" through `/rtk status` gets the same warn-once-per-outage notification as a user who discovers it through a bash rewrite failure.

The toggle is intentionally **in-memory only**: it resets to enabled on every Pi process start and is never persisted to disk. This matches the project's zero-config stance and keeps the surface narrow — persistence is a separate, larger feature with its own UX questions (per-project? global? TTL?). The README and `/rtk status` both make the session-scoped behavior explicit.

## What changes

* **`index.ts`** — module-level `sessionEnabled` boolean with getter / setter helpers, a `VALID_RTK_SUBCOMMANDS` literal union and matching `isRtkSubcommand` type guard, the `handleRtkSubcommand` dispatcher, `showRtkOverlay` (the bare-`/rtk` interactive picker), `showRtkStatus` (notify-rendered multi-line status report), `rtkStatusReport` (gate-respecting version + path detector that reuses `classifySpawnError` + `alertRtkUnavailable`), `renderStatusText` and `updateFooterStatus` for the footer indicator. The agent `bash` `spawnHook` and the `user_bash` handler both short-circuit when `sessionEnabled === false`, placed BEFORE the rewrite call so no `rtk` subprocess is spawned when the toggle is off. `pi.registerCommand("rtk", ...)` registers the command with description, argument completions, and the dispatch handler. Footer is initialized in the `session_start` handler.
* **`openspec/specs/infrastructure/spec.md`** — new requirement `/rtk Slash Command Registration` with 3 scenarios (registration at load; argument completion lists valid subcommands; unknown subcommand is rejected without state change).
* **`openspec/specs/shell-optimization/spec.md`** — new requirements `Session Toggle Gates Rewrite Attempt` (3 scenarios) and `Toggle Composes With Per-Command Bypass` (2 scenarios). The orthogonality requirement locks in that the session toggle and rtk's per-command env-prefix bypass are independent: enabled session + per-command prefix means rtk is called and rtk bails on the prefix; disabled session short-circuits regardless of prefix.
* **`openspec/specs/user-interaction/spec.md`** — four new requirements: `Session-Scoped Rewrite Toggle` (3 scenarios), `Persistent Footer State Indicator` (2 scenarios), `/rtk Bare Invocation Opens Settings Overlay` (1 scenario), `/rtk Status Report` (2 scenarios — including the explicit "does not inspect process environment" scenario that locks in the Position 1 stance on `process.env.RTK_DISABLED`). All synced verbatim from the change's delta.
* **`README.md`** — new `/rtk` Slash Command section between the `User !!<cmd>` section and the `What pi-rtk Does Not Do` section, documenting the four invocations, the footer indicator with new semantic colors, the session-scoped semantics, and the per-command bypass example (`!RTK_DISABLED=1 <cmd>`).
* **`openspec/changes/archive/2026-05-13-add-rtk-slash-command/`** — the completed change's proposal, design, four spec deltas, and task list. design.md captures eight load-bearing decisions including the two follow-on decisions added pre-implementation (slash handler does NOT cacheNotify; `/rtk status` reuses the existing availability gate).

## What does **not** change

* **The agent `bash` rewrite path when the toggle is enabled.** `createBashTool({ spawnHook })` still spawns `rtk rewrite` exactly once per agent-issued bash command. The `cache-user-bash-rewrite` invariant is preserved.
* **The `user_bash` excludeFromContext semantics.** The `!!<cmd>` guard still runs FIRST in the user_bash handler — before the toggle check, before the rewrite call — so the user's "do not show this output to the model" choice is never affected by the toggle state.
* **The notify-when-rtk-unavailable infrastructure.** This PR reuses `classifySpawnError`, `alertRtkUnavailable`, `cachedNotify`, and the warn-once-per-outage gate without modification. No new detection mechanism, no new helpers, no parallel notification path.
* **The exit-code-trust stance** in `rtkRewriteCommand`. Deny verdicts still pass through; only the new toggle gating is added at the call sites, the function body is byte-identical to before this PR.
* **Process-env detection.** The Position 1 stance (don't read `process.env.RTK_DISABLED`) is preserved and locked in via a spec scenario.

## Verification

* `mise run check` — `format-check`, `type-check`, `biome lint`, and `eslint .` all clean.
* `openspec validate add-rtk-slash-command --strict` — passes (re-run after the spec sync, before the archive move).
* `diff` of each main spec section against the corresponding change delta: **identical scenarios in identical order** across all three modified capabilities (infrastructure, shell-optimization, user-interaction).
* Manual smokes (tasks 8.4–8.6) confirmed:
    - `/rtk` overlay, `/rtk status`, `/rtk enable`, `/rtk disable`, `/rtk garbage` all behave per spec.
    - With toggle off, an agent bash call does NOT spawn rtk (verified via temporary instrumentation).
    - With toggle on, `!RTK_DISABLED=1 git status` reaches rtk and rtk bails on the env prefix (orthogonality preserved).
    - With rtk missing, `/rtk status` renders `rtk not detected on PATH` AND fires the standard ENOENT warning toast — the warn-once gate already prevents a duplicate if the session-start probe already fired.

## Closes openspec change

`add-rtk-slash-command`.

## Note on the review iterations

The implementation went through one round of user-flagged adjustments before landing in this PR:

1. **`/rtk status` originally used `ctx.ui.select`** to display the report. Flagged as misleading — a picker implies actionable items, but the lines are pure information. Replaced with a multi-line `ctx.ui.notify` so the status reads as a transient info toast.
2. **Footer originally used `rtk ●` in `dim` (enabled) and `rtk ○ off` in `warning` (disabled).** The dim color made the enabled state recede when it should be the "everything is normal" green-light signal, and the filled/hollow circle distinction was too subtle. Replaced with `rtk ✓` in `success` (green) for enabled and `rtk ✗` in `error` (red) for disabled — semantic color carries the meaning and the symbols are colorblind-safe.
3. **Tip wording was originally `RTK_DISABLED=<value> <cmd>`.** Flagged as (a) asking users to guess what `<value>` means when `1` is the conventional choice, and (b) missing the Pi user-shell `!` prefix that users actually type. Updated to `!RTK_DISABLED=1 <cmd>` everywhere user-facing; the technical references to rtk's env-prefix contract continue to use the bare `RTK_DISABLED=1` form since rtk does not understand the `!` prefix.

Each iteration's rationale is captured in `design.md` and the rejected-alternative paragraphs survive in the archived change.
