### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This changelog follows [Common Changelog](https://common-changelog.org/).
 
+## [0.6.0] - 2026-05-13
+
+### Added
+
+- A `/rtk` slash command for session-scoped control. `/rtk enable` and `/rtk disable` toggle rewriting on and off for the current Pi session; `/rtk status` shows the toggle state, the detected `rtk` binary version and path, and a tip on how to bypass rtk for a single command. A bare `/rtk` invocation opens an overlay with the same actions. The toggle is in-memory only and resets to enabled each time Pi starts. ([#13](https://github.com/sherif-fanous/pi-rtk/pull/13))
+- A persistent footer indicator showing whether rewriting is currently active: `rtk ✓` in green when enabled, `rtk ✗` in red when disabled. ([#13](https://github.com/sherif-fanous/pi-rtk/pull/13))
+- A warning notification when the `rtk` binary cannot be reached. The notification fires at session start if `rtk` is missing from PATH or not executable, and again mid-session if `rtk` becomes unavailable while Pi is running. At most one notification per outage — reinstalling `rtk` mid-session resets the gate so a subsequent removal will warn again. ([#12](https://github.com/sherif-fanous/pi-rtk/pull/12))
+
+### Changed
+
+- Reduced latency on user-issued `!<cmd>` shell commands by reusing the probe-time rewrite result rather than recomputing it. Same output, fewer subprocess spawns. ([#10](https://github.com/sherif-fanous/pi-rtk/pull/10))
+
 ## [0.5.0] - 2026-05-12
 
 ### Changed
@@ -30,6 +42,7 @@ This changelog follows [Common Changelog](https://common-changelog.org/).
 
 _Initial release._
 
+[0.6.0]: https://github.com/sherif-fanous/pi-rtk/releases/tag/v0.6.0
 [0.5.0]: https://github.com/sherif-fanous/pi-rtk/releases/tag/v0.5.0
 [0.4.0]: https://github.com/sherif-fanous/pi-rtk/releases/tag/v0.4.0
 [0.3.0]: https://github.com/sherif-fanous/pi-rtk/releases/tag/v0.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherif-fanous/pi-rtk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Pi extension that routes bash commands through rtk (Rust Token Killer) for LLM token savings",
   "keywords": [
     "pi",


### PR DESCRIPTION
## Summary

Release commit for **v0.6.0**. Bundles the four user-visible changes that landed on `main` after v0.5.0:

* **PR [feat: add /rtk slash command, footer indicator, and session toggle #13](https://github.com/sherif-fanous/pi-rtk/pull/13)** — `/rtk enable`, `/rtk disable`, `/rtk status`, bare-`/rtk` overlay, plus a persistent footer indicator (`rtk ✓` green / `rtk ✗` red).
* **PR [feat: notify the user when rtk becomes unavailable #12](https://github.com/sherif-fanous/pi-rtk/pull/12)** — warn-once-per-outage TUI notification when the `rtk` binary is missing from PATH (ENOENT) or not executable (EACCES).
* **PR [perf(user_bash): dedupe rtk rewrite call at probe time #10](https://github.com/sherif-fanous/pi-rtk/pull/10)** — halves rtk subprocess spawns for user-issued `!<cmd>` shell commands.
* **PR [docs: codify pi-rtk's no-deny-enforcement scope #9](https://github.com/sherif-fanous/pi-rtk/pull/9)** — locks pi-rtk's non-enforcement of rtk's deny verdict into the spec, plus a user-facing `What pi-rtk Does Not Do` section in the README.

This is a **minor** release: no breaking changes, no API removals. v0.6.0 is forward-compatible with v0.5.0 — users can upgrade in place.

## What changes

* **`package.json`** — bump `version` from `0.5.0` to `0.6.0`.
* **`CHANGELOG.md`** — add `[0.6.0] - 2026-05-13` section with three `### Added` bullets (`/rtk` slash command, footer indicator, rtk-unavailable warning) and one `### Changed` bullet (reduced `!<cmd>` latency). Each bullet describes a single user-visible change and links to the PR that introduced it. Release link `[0.6.0]: …/releases/tag/v0.6.0` prepended to the link footer in descending-version order. Per project convention, the CHANGELOG documents end-user-visible changes only; technical detail belongs in the commit history and the merged PRs.

Common Changelog format preserved (`### Added` and `### Changed` categories, no breaking-change marker since v0.5.0 → v0.6.0 is forward-compatible).

## What does **not** change

* **Source code, tests, or any non-bookkeeping file.** All implementation already merged via PRs #9, #10, #11 (internal cleanup, not in CHANGELOG), #12, and #13.
* **OpenSpec.** No new change required — release commits are bookkeeping, not specifiable behavior. The four substantive changes that this release bundles were each archived under `openspec/changes/archive/2026-05-13-*` when they were merged.
* **Dependencies.** No `package.json` dependency or peer-dependency changes since v0.5.0; only the `version` field is updated.

## Verification

* `mise run check` — `format-check`, `type-check`, `biome lint`, and `eslint .` all clean.
* Manual: read `CHANGELOG.md` end-to-end; entries are end-user-perspective only (no `spawnSync`, no `classifySpawnError`, no PR-internal architecture detail), format matches Common Changelog convention and the existing v0.1.0–v0.5.0 entries.
* The four PRs being released were each verified independently before merge (each PR body lists its own `mise run check` + `openspec validate --strict` + manual smoke results).

## Post-merge plan

After this PR merges to `main`:

1. Tag `v0.6.0` on the resulting merge commit (annotated tag, `v0.6.0 — <summary>` per repo convention).
2. `git push origin v0.6.0`.
3. `mise run publish`.
4. Optional: create a GitHub release pointing at the tag with the CHANGELOG entry as the release body.
